### PR TITLE
Path preview simulation, UI updates, safety features

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -149,39 +149,39 @@ async def preview_path(
     await manager.broadcast_to_group(group=manager.robot_connections, state=manager.desired_state)
 
     # --- REAL MODE (Default): Return empty path, Frontend waits for WS ---
-    return {
-        "status": "pending",
-        "duration": 0,
-        "path": [], 
-        "message": "Computation initiated on Robot"
-    }
+    # return {
+    #     "status": "pending",
+    #     "duration": 0,
+    #     "path": [], 
+    #     "message": "Computation initiated on Robot"
+    # }
 
     # --- FAKE MODE (Uncomment for testing without Robot) ---
-    # final_path = []
-    # duration = 0
+    final_path = []
+    duration = 0
 
-    # if is_fill:
-    #     final_path = generate_fake_raster_path(pixel_list, density)
-    # else:
-    #     final_path = pixel_list[::5]
+    if is_fill:
+        final_path = generate_fake_raster_path(pixel_list, density)
+    else:
+        final_path = pixel_list[::5]
 
-    # total_distance = 0
-    # if len(final_path) > 1:
-    #     for i in range(1, len(final_path)):
-    #         dx = final_path[i]['x'] - final_path[i-1]['x']
-    #         dy = final_path[i]['y'] - final_path[i-1]['y']
-    #         total_distance += math.sqrt(dx*dx + dy*dy)
+    total_distance = 0
+    if len(final_path) > 1:
+        for i in range(1, len(final_path)):
+            dx = final_path[i]['x'] - final_path[i-1]['x']
+            dy = final_path[i]['y'] - final_path[i-1]['y']
+            total_distance += math.sqrt(dx*dx + dy*dy)
 
-    # fake_speed_factor = speed * 10
-    # if fake_speed_factor == 0: fake_speed_factor = 1
-    # duration = (total_distance / fake_speed_factor) + random.uniform(0.5, 1.5)
+    fake_speed_factor = speed * 10
+    if fake_speed_factor == 0: fake_speed_factor = 1
+    duration = (total_distance / fake_speed_factor) + random.uniform(0.5, 1.5)
 
-    # return {
-    #     "status": "success",
-    #     "duration": duration,
-    #     "path": final_path,
-    #     "message": "Preview data sent to robot (Simulation)"
-    # }
+    return {
+        "status": "success",
+        "duration": duration,
+        "path": final_path,
+        "message": "Preview data sent to robot (Simulation)"
+    }
     
 # --- EXECUTION ENDPOINT ---
 @app.post("/api/execute")

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -56,7 +56,7 @@ async def execute_fixtures(file: UploadFile = File(...)):
         "message": "Fixtures mask dispatched to robot"
     }
 
-# --- CORRECTED ENDPOINT ---
+# --- EXECUTION ENDOINT ---
 @app.post("/api/execute")
 async def execute_bundled_command(
     speed: float = Form(...),
@@ -175,7 +175,6 @@ def generate_fake_raster_path(pixel_list: List[Dict[str, float]], density: float
     """
     if not pixel_list: return []
 
-    # 1. Calculate Bounding Box
     xs = [p['x'] for p in pixel_list]
     ys = [p['y'] for p in pixel_list]
     min_x, max_x = min(xs), max(xs)
@@ -183,7 +182,6 @@ def generate_fake_raster_path(pixel_list: List[Dict[str, float]], density: float
 
     generated_path = []
     
-    # Calculate step size (inverted: higher density = smaller step)
     step = max(10.0, 200.0 / (density if density > 0 else 1)) 
     
     current_y = min_y
@@ -194,7 +192,6 @@ def generate_fake_raster_path(pixel_list: List[Dict[str, float]], density: float
         start_x = min_x if going_right else max_x
         end_x = max_x if going_right else min_x
         
-        # Interpolation Logic
         dist = abs(end_x - start_x)
         num_sub_steps = int(dist / point_resolution)
         direction = 1 if end_x > start_x else -1
@@ -214,10 +211,7 @@ def generate_fake_raster_path(pixel_list: List[Dict[str, float]], density: float
         
     return generated_path
 
-# ============================================================================
-#  PREVIEW ENDPOINT
-# ============================================================================
-
+# --- PREVIEW ENDPOINT ---
 @app.post("/api/preview")
 async def preview_path(
     speed: float = Form(...),

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -149,12 +149,12 @@ async def preview_path(
     await manager.broadcast_to_group(group=manager.robot_connections, state=manager.desired_state)
 
     # --- REAL MODE (Default): Return empty path, Frontend waits for WS ---
-    # return {
-    #     "status": "pending",
-    #     "duration": 0,
-    #     "path": [], 
-    #     "message": "Computation initiated on Robot"
-    # }
+    return {
+        "status": "pending",
+        "duration": 0,
+        "path": [], 
+        "message": "Computation initiated on Robot"
+    }
 
     # --- FAKE MODE (Uncomment for testing without Robot) ---
     final_path = []

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,3 +1,5 @@
+#backend/src/main.py
+
 from fastapi import FastAPI, HTTPException, WebSocket, UploadFile, Request, Form, File
 from fastapi.middleware.cors import CORSMiddleware
 import os
@@ -9,7 +11,6 @@ from typing import Optional
 import random
 import math
 from typing import Optional, List, Dict, Any
-import httpx
 
 app = FastAPI()
 
@@ -56,9 +57,55 @@ async def execute_fixtures(file: UploadFile = File(...)):
         "message": "Fixtures mask dispatched to robot"
     }
 
-# --- EXECUTION ENDOINT ---
-@app.post("/api/execute")
-async def execute_bundled_command(
+# ============================================================================
+#  PATH GENERATION HELPERS
+# ============================================================================
+
+def generate_fake_raster_path(pixel_list: List[Dict[str, float]], density: float) -> List[Dict[str, float]]:
+    """
+    Fallback simulation: creates a zig-zag pattern within the bounding box.
+    """
+    if not pixel_list: return []
+
+    xs = [p['x'] for p in pixel_list]
+    ys = [p['y'] for p in pixel_list]
+    min_x, max_x = min(xs), max(xs)
+    min_y, max_y = min(ys), max(ys)
+
+    generated_path = []
+    
+    step = max(10.0, 200.0 / (density if density > 0 else 1)) 
+    
+    current_y = min_y
+    going_right = True
+    point_resolution = 10.0 
+
+    while current_y <= max_y:
+        start_x = min_x if going_right else max_x
+        end_x = max_x if going_right else min_x
+        
+        dist = abs(end_x - start_x)
+        num_sub_steps = int(dist / point_resolution)
+        direction = 1 if end_x > start_x else -1
+        
+        if num_sub_steps < 1:
+            generated_path.append({"x": start_x, "y": current_y})
+            generated_path.append({"x": end_x, "y": current_y})
+        else:
+            for i in range(num_sub_steps + 1):
+                x_pos = start_x + (i * point_resolution * direction)
+                if direction > 0: x_pos = min(x_pos, end_x)
+                else:             x_pos = max(x_pos, end_x)
+                generated_path.append({"x": x_pos, "y": current_y})
+
+        current_y += step
+        going_right = not going_right
+        
+    return generated_path
+
+# --- PREVIEW ENDPOINT ---
+@app.post("/api/preview")
+async def preview_path(
     speed: float = Form(...),
     raster_type: str = Form(None),
     density: float = Form(...),
@@ -66,6 +113,10 @@ async def execute_bundled_command(
     is_fill: bool = Form(...),
     file: Optional[UploadFile] = File(None)
 ):
+    """
+    Preview endpoint now sends all execution data to the robot for path computation.
+    The robot will compute the path and send it back via websocket.
+    """
     try:
         pixel_list = json.loads(pixels)
     except json.JSONDecodeError:
@@ -73,7 +124,7 @@ async def execute_bundled_command(
 
     encoded_utf8 = None
 
-    # Only process the file if it was actually sent
+    # Process the file if it was sent (for raster fills)
     if file:
         file_content = await file.read()
         save_directory = "saved_masks"
@@ -85,23 +136,77 @@ async def execute_bundled_command(
 
         encoded_utf8 = base64.b64encode(file_content).decode('utf-8')
 
+    # Update desired state with ALL path data
     manager.desired_state.speed = speed
     manager.desired_state.raster_type = raster_type if encoded_utf8 is not None else None
     manager.desired_state.density = density
     manager.desired_state.path = pixel_list
-    # If no file, we explicitly set the mask to None or empty so the robot knows not to raster
     manager.desired_state.raster_mask = encoded_utf8 if encoded_utf8 is not None else None
+    manager.desired_state.pathPrepared = True  # Mark as prepared
+    manager.desired_state.executeCommand = False  # Not executing yet
 
-    print(f"Bundled Execution: Broadcasting {len(pixel_list)} pixels. Fill: {is_fill}")
+    print(f"Preview: Broadcasting {len(pixel_list)} pixels for path computation. Fill: {is_fill}")
+    await manager.broadcast_to_group(group=manager.robot_connections, state=manager.desired_state)
+
+    # --- REAL MODE (Default): Return empty path, Frontend waits for WS ---
+    return {
+        "status": "pending",
+        "duration": 0,
+        "path": [], 
+        "message": "Computation initiated on Robot"
+    }
+
+    # --- FAKE MODE (Uncomment for testing without Robot) ---
+    # final_path = []
+    # duration = 0
+
+    # if is_fill:
+    #     final_path = generate_fake_raster_path(pixel_list, density)
+    # else:
+    #     final_path = pixel_list[::5]
+
+    # total_distance = 0
+    # if len(final_path) > 1:
+    #     for i in range(1, len(final_path)):
+    #         dx = final_path[i]['x'] - final_path[i-1]['x']
+    #         dy = final_path[i]['y'] - final_path[i-1]['y']
+    #         total_distance += math.sqrt(dx*dx + dy*dy)
+
+    # fake_speed_factor = speed * 10
+    # if fake_speed_factor == 0: fake_speed_factor = 1
+    # duration = (total_distance / fake_speed_factor) + random.uniform(0.5, 1.5)
+
+    # return {
+    #     "status": "success",
+    #     "duration": duration,
+    #     "path": final_path,
+    #     "message": "Preview data sent to robot (Simulation)"
+    # }
+    
+# --- EXECUTION ENDPOINT ---
+@app.post("/api/execute")
+async def execute_path():
+    """
+    Execute endpoint now only sends the execute command.
+    All path data should already be prepared via the preview endpoint.
+    """
+    if not manager.desired_state.pathPrepared:
+        raise HTTPException(
+            status_code=400, 
+            detail="Path not prepared. Please preview the path first."
+        )
+
+    # Set execute command flag
+    manager.desired_state.executeCommand = True
+
+    print(f"Execute: Sending start command to robot")
     await manager.broadcast_to_group(group=manager.robot_connections, state=manager.desired_state)
 
     return {
         "status": "success",
-        "message": "Full execution packet dispatched to robot",
-        "pixel_count": len(pixel_list),
-        "has_raster": encoded_utf8 is not None
+        "message": "Execute command dispatched to robot"
     }
-
+    
 @app.post("/api/view_settings")
 async def submit_settings(request: Request):
     data = await request.json()
@@ -162,108 +267,6 @@ async def update_heat_area(file: UploadFile = File(...)):
     return {
         "status": "success", 
         "message": "Heat area mask saved and dispatched"
-    }
-    
-    
-# ============================================================================
-#  PATH GENERATION HELPERS
-# ============================================================================
-
-def generate_fake_raster_path(pixel_list: List[Dict[str, float]], density: float) -> List[Dict[str, float]]:
-    """
-    Fallback simulation: creates a zig-zag pattern within the bounding box.
-    """
-    if not pixel_list: return []
-
-    xs = [p['x'] for p in pixel_list]
-    ys = [p['y'] for p in pixel_list]
-    min_x, max_x = min(xs), max(xs)
-    min_y, max_y = min(ys), max(ys)
-
-    generated_path = []
-    
-    step = max(10.0, 200.0 / (density if density > 0 else 1)) 
-    
-    current_y = min_y
-    going_right = True
-    point_resolution = 10.0 
-
-    while current_y <= max_y:
-        start_x = min_x if going_right else max_x
-        end_x = max_x if going_right else min_x
-        
-        dist = abs(end_x - start_x)
-        num_sub_steps = int(dist / point_resolution)
-        direction = 1 if end_x > start_x else -1
-        
-        if num_sub_steps < 1:
-            generated_path.append({"x": start_x, "y": current_y})
-            generated_path.append({"x": end_x, "y": current_y})
-        else:
-            for i in range(num_sub_steps + 1):
-                x_pos = start_x + (i * point_resolution * direction)
-                if direction > 0: x_pos = min(x_pos, end_x)
-                else:             x_pos = max(x_pos, end_x)
-                generated_path.append({"x": x_pos, "y": current_y})
-
-        current_y += step
-        going_right = not going_right
-        
-    return generated_path
-
-# --- PREVIEW ENDPOINT ---
-@app.post("/api/preview")
-async def preview_path(
-    speed: float = Form(...),
-    raster_type: str = Form(None),
-    density: float = Form(...),
-    pixels: str = Form(...),
-    is_fill: bool = Form(...),
-    file: Optional[UploadFile] = File(None)
-):
-    try:
-        pixel_list = json.loads(pixels)
-    except json.JSONDecodeError:
-        raise HTTPException(status_code=400, detail="Invalid pixel data format")
-
-    final_path = []
-    duration = 0
-
-    # ==============================================================================
-    # TODO: ROBOT INTEGRATION SECTION
-    # ==============================================================================
-    #Construct payload to send to backend, similar to execution
-    #Send to backend to generate the path
-    #Wait for the response containing path and duration
-    #Take that path, and do what's necessary
-    # ==============================================================================
-
-    # --- CURRENT SIMULATION LOGIC ---
-    # For now, we simulate the path locally so the UI works.
-    if is_fill:
-        final_path = generate_fake_raster_path(pixel_list, density)
-    else:
-        final_path = pixel_list[::5] # Simple vector outline
-
-    # Calculate simulated duration
-    total_distance = 0
-    if len(final_path) > 1:
-        for i in range(1, len(final_path)):
-            dx = final_path[i]['x'] - final_path[i-1]['x']
-            dy = final_path[i]['y'] - final_path[i-1]['y']
-            total_distance += math.sqrt(dx*dx + dy*dy)
-
-    fake_speed_factor = speed * 10
-    if fake_speed_factor == 0: fake_speed_factor = 1
-    duration = (total_distance / fake_speed_factor) + random.uniform(0.5, 1.5)
-    # --- END SIMULATION LOGIC ---
-
-    #Return necessary values to frontend for visualization
-    return {
-        "status": "success",
-        "duration": duration,
-        "path": final_path,
-        "message": "Preview generated (Simulation)"
     }
 
 ws_ui_name = os.getenv("UI_WEBSOCKET_NAME", "ui")

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -149,12 +149,12 @@ async def preview_path(
     await manager.broadcast_to_group(group=manager.robot_connections, state=manager.desired_state)
 
     # --- REAL MODE (Default): Return empty path, Frontend waits for WS ---
-    return {
-        "status": "pending",
-        "duration": 0,
-        "path": [], 
-        "message": "Computation initiated on Robot"
-    }
+    # return {
+    #     "status": "pending",
+    #     "duration": 0,
+    #     "path": [], 
+    #     "message": "Computation initiated on Robot"
+    # }
 
     # --- FAKE MODE (Uncomment for testing without Robot) ---
     final_path = []

--- a/backend/src/manager.py
+++ b/backend/src/manager.py
@@ -1,3 +1,5 @@
+#backend/src/manager.py
+
 import json
 from robot import RobotSchema
 from fastapi import WebSocket, WebSocketDisconnect

--- a/backend/src/robot.py
+++ b/backend/src/robot.py
@@ -1,3 +1,5 @@
+#backend/src/robot.py
+
 import json
 from dataclasses import dataclass, asdict
 from typing import List, Dict, Optional, Any
@@ -35,10 +37,16 @@ class RobotSchema:
     raster_type: Optional[str] = None
     speed: Optional[float] = None
     height: Optional[float] = None
+    density: Optional[float] = None
     
     # Complex Data
     path: Optional[List[Dict[str, float]]] = None
     heat_markers: Optional[List[Dict[str, float]]] = None
+    
+    #Path preparation
+    pathPrepared: Optional[bool] = None
+    executeCommand: Optional[bool] = None
+    path_preview: Optional[Dict[str, List[float]]] = None
 
     def flush(self) -> str:
         """
@@ -53,6 +61,8 @@ class RobotSchema:
         self.path = None
         self.heat_mask = None
         self.heat_markers = None
+        self.path_preview = None # Reset after sending
+        self.executeCommand = None
         
         # Clear motion commands, persist laserX and laserY but not x and y
         self.x = None

--- a/backend/src/robot.py
+++ b/backend/src/robot.py
@@ -47,6 +47,7 @@ class RobotSchema:
     pathPrepared: Optional[bool] = None
     executeCommand: Optional[bool] = None
     path_preview: Optional[Dict[str, List[float]]] = None
+    preview_duration: Optional[float] = None
 
     def flush(self) -> str:
         """
@@ -62,6 +63,7 @@ class RobotSchema:
         self.heat_mask = None
         self.heat_markers = None
         self.path_preview = None # Reset after sending
+        self.preview_duration = None
         self.executeCommand = None
         
         # Clear motion commands, persist laserX and laserY but not x and y

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,6 +22,23 @@
 <body>
   <div id="app-scaler">
     <div id="overlay"></div>
+    <div id="previewPopup">
+      <div class="preview-header">
+        <div class="preview-info">
+          <h3>Simulation</h3>
+          <span id="previewTimeDisplay">Est. Time: -- s</span>
+        </div>
+        <button id="previewCloseBtn">
+          <svg width="24" height="24" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path d="M18 6L6 18M6 6L18 18" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </button>
+      </div>
+      <div class="preview-viewport" id="previewContainer">
+        <canvas id="previewCanvas"></canvas>
+        <div id="previewMarker"></div>
+      </div>
+    </div>
     <div id="preparePopup">
       <div class="prepare-header">
         <h2>Prepare Path</h2>
@@ -34,61 +51,84 @@
       </div>
       <div class="prepare-body">
         <div class="control-group">
-          <label for="speedInput" class="input-label">Robot Speed (mm/s)</label>
-          <div class="input-wrapper">
-            <input type="number" id="speedInput" class="styled-input" value="10" step="10" min="1" max="100"
-              placeholder="e.g. 10">
+
+          <!-- Speed Input - NO container -->
+          <div class="speed-input-wrapper">
+            <label for="speedInput" class="input-label">Robot Speed (mm/s)</label>
+            <div class="input-wrapper">
+              <input type="number" id="speedInput" class="styled-input" value="10" step="10" min="1" max="100"
+                placeholder="e.g. 10">
+            </div>
           </div>
 
+          <!-- Fill Shape Toggle Container -->
+          <div class="fill-toggle-container">
+            <span class="input-label">Fill Shape</span>
+            <div class="segment-control" style="width: 140px;">
+              <button id="fillOff" class="segment-btn active">Off</button>
+              <button id="fillOn" class="segment-btn">On</button>
+            </div>
+          </div>
+
+          <!-- Accordion Panel (outside container) -->
           <div class="fill-accordion-container">
-
-            <button id="fillAccordionToggle" class="fill-accordion-toggle">
-              <span class="fill-toggle-text">Fill Shape</span>
-              <div class="fill-toggle-icon">
-                <svg width="12" height="8" viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M1.41 0.589996L6 5.17L10.59 0.589996L12 2L6 8L0 2L1.41 0.589996Z" fill="currentColor" />
-                </svg>
-              </div>
-            </button>
-
             <div id="fillSettingsPanel" class="fill-settings-panel">
               <div class="fill-settings-inner">
 
-                <p class="fill-setting-label">Raster Pattern:</p>
-                <div class="segment-control">
-                  <button id="rasterA" class="segment-btn active">Line</button>
-                  <button id="rasterB" class="segment-btn">Spiral</button>
+                <!-- Raster Pattern Section -->
+                <div class="raster-pattern-section">
+                  <label class="fill-setting-label">Raster Pattern</label>
+                  <div class="segment-control raster-pattern-control">
+                    <button id="rasterA" class="segment-btn active">Line</button>
+                    <button id="rasterB" class="segment-btn">Spiral</button>
+                  </div>
                 </div>
 
-                <div class="density-wrapper">
-                  <label for="densityRaster" class="fill-setting-label">Density:</label>
-                  <input type="number" id="densityRaster" class="styled-input-density" value="10" step="1" min="1"
-                    max="20" placeholder="10">
+                <!-- Density Section -->
+                <div class="density-section">
+                  <div class="density-wrapper">
+                    <label for="densityRaster" class="fill-setting-label">Density:</label>
+                    <input type="number" id="densityRaster" class="styled-input-density" value="10" step="1" min="1"
+                      max="20" placeholder="10">
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
 
+          <!-- Preview Button -->
+          <div class="preview-action-container">
+            <button id="previewPathBtn" class="action-btn">
+              <span class="btn-icon">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <polygon points="5 3 19 12 5 21 5 3"></polygon>
+                </svg>
+              </span>
+              <span class="btn-text">PREVIEW PATH</span>
+            </button>
+          </div>
 
-        <div id="bottomButtons">
-          <button id="prepareCancelBtn" class="action-btn action-btn-cancel">
-            <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-              <path
-                d="M8 0C3.589 0 0 3.589 0 8C0 12.411 3.589 16 8 16C12.411 16 16 12.411 16 8C16 3.589 12.411 0 8 0ZM3 8C3 7.168 3.224 6.396 3.584 5.705L10.295 12.416C9.58866 12.7939 8.80103 12.9943 8 13C5.243 13 3 10.757 3 8ZM12.416 10.295L5.705 3.584C6.41134 3.20614 7.19897 3.00571 8 3C10.757 3 13 5.243 13 8C13 8.832 12.776 9.604 12.416 10.295Z" />
-            </svg>
-            <span class="btn-text">CANCEL</span>
-          </button>
-
-          <button id="executeBtn" class="action-btn action-btn-execute" data-state="ready">
-            <span class="btn-icon">
-              <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+          <!-- Bottom Buttons -->
+          <div id="bottomButtons">
+            <button id="prepareCancelBtn" class="action-btn action-btn-cancel">
+              <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
                 <path
-                  d="M10 0C15.523 0 20 4.477 20 10C20 15.523 15.523 20 10 20C4.477 20 0 15.523 0 10C0 4.477 4.477 0 10 0ZM10 13C9.73478 13 9.48043 13.1054 9.29289 13.2929C9.10536 13.4804 9 13.7348 9 14C9 14.2652 9.10536 14.5196 9.29289 14.7071C9.48043 14.8946 9.73478 15 10 15C10.2652 15 10.5196 14.8946 10.7071 14.7071C10.8946 14.5196 11 14.2652 11 14C11 13.7348 10.8946 13.4804 10.7071 13.2929C10.5196 13.1054 10.2652 13 10 13ZM10 4C9.75507 4.00003 9.51866 4.08996 9.33563 4.25272C9.15259 4.41547 9.03566 4.63975 9.007 4.883L9 5V11C9.00028 11.2549 9.09788 11.5 9.27285 11.6854C9.44782 11.8707 9.68695 11.9822 9.94139 11.9972C10.1958 12.0121 10.4464 11.9293 10.6418 11.7657C10.8373 11.6021 10.9629 11.3701 10.993 11.117L11 11V5C11 4.73478 10.8946 4.48043 10.7071 4.29289C10.5196 4.10536 10.2652 4 10 4Z" />
+                  d="M8 0C3.589 0 0 3.589 0 8C0 12.411 3.589 16 8 16C12.411 16 16 12.411 16 8C16 3.589 12.411 0 8 0ZM3 8C3 7.168 3.224 6.396 3.584 5.705L10.295 12.416C9.58866 12.7939 8.80103 12.9943 8 13C5.243 13 3 10.757 3 8ZM12.416 10.295L5.705 3.584C6.41134 3.20614 7.19897 3.00571 8 3C10.757 3 13 5.243 13 8C13 8.832 12.776 9.604 12.416 10.295Z" />
               </svg>
-            </span>
-            <span class="btn-text">EXECUTE</span>
-          </button>
+              <span class="btn-text">CANCEL</span>
+            </button>
+
+            <button id="executeBtn" class="action-btn action-btn-execute" data-state="ready">
+              <span class="btn-icon">
+                <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                  <path
+                    d="M10 0C15.523 0 20 4.477 20 10C20 15.523 15.523 20 10 20C4.477 20 0 15.523 0 10C0 4.477 4.477 0 10 0ZM10 13C9.73478 13 9.48043 13.1054 9.29289 13.2929C9.10536 13.4804 9 13.7348 9 14C9 14.2652 9.10536 14.5196 9.29289 14.7071C9.48043 14.8946 9.73478 15 10 15C10.2652 15 10.5196 14.8946 10.7071 14.7071C10.8946 14.5196 11 14.2652 11 14C11 13.7348 10.8946 13.4804 10.7071 13.2929C10.5196 13.1054 10.2652 13 10 13ZM10 4C9.75507 4.00003 9.51866 4.08996 9.33563 4.25272C9.15259 4.41547 9.03566 4.63975 9.007 4.883L9 5V11C9.00028 11.2549 9.09788 11.5 9.27285 11.6854C9.44782 11.8707 9.68695 11.9822 9.94139 11.9972C10.1958 12.0121 10.4464 11.9293 10.6418 11.7657C10.8373 11.6021 10.9629 11.3701 10.993 11.117L11 11V5C11 4.73478 10.8946 4.48043 10.7071 4.29289C10.5196 4.10536 10.2652 4 10 4Z" />
+                </svg>
+              </span>
+              <span class="btn-text">EXECUTE</span>
+            </button>
+          </div>
+
         </div>
       </div>
     </div>
@@ -292,8 +332,7 @@
             <button id="realTimePen" class="icon-btn icon-btn-fill real-time-ui hidden-mode">
               <svg width="22" height="22" viewBox="0 0 17 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
                 <path
-                  d="M5.0458 11L1.0458 14C0.0458035 14.88 -0.0941965 16.12 0.0458035 17C0.175804 18 0.955804 19.22 2.0458 19.68C3.6158 20.35 5.1358 19.9 6.0858 18.92L15.0458 11C16.9058 9.62 16.0458 7 14.0458 7H8.0458L15.5058 2.61C15.9458 2.29 16.1258 1.82 16.1058 1.37C16.0458 0.67 15.5058 0 14.6458 0H14.5858C14.2358 0 13.9058 0.11 13.6058 0.29L1.0458 7C0.235804 7.46 -0.0141965 8.24 0.0458035 9C0.0958035 10.03 0.785804 11 2.0458 11M1.0458 16.5C1.0458 15.837 1.3092 15.2011 1.77804 14.7322C2.24688 14.2634 2.88276 14 3.5458 14C4.20884 14 4.84473 14.2634 5.31357 14.7322C5.78241 15.2011 6.0458 15.837 6.0458 16.5C6.0458 17.163 5.78241 17.7989 5.31357 18.2678C4.84473 18.7366 4.20884 19 3.5458 19C2.88276 19 2.24688 18.7366 1.77804 18.2678C1.3092 17.7989 1.0458 17.163 1.0458 16.5Z"
-                  />
+                  d="M5.0458 11L1.0458 14C0.0458035 14.88 -0.0941965 16.12 0.0458035 17C0.175804 18 0.955804 19.22 2.0458 19.68C3.6158 20.35 5.1358 19.9 6.0858 18.92L15.0458 11C16.9058 9.62 16.0458 7 14.0458 7H8.0458L15.5058 2.61C15.9458 2.29 16.1258 1.82 16.1058 1.37C16.0458 0.67 15.5058 0 14.6458 0H14.5858C14.2358 0 13.9058 0.11 13.6058 0.29L1.0458 7C0.235804 7.46 -0.0141965 8.24 0.0458035 9C0.0958035 10.03 0.785804 11 2.0458 11M1.0458 16.5C1.0458 15.837 1.3092 15.2011 1.77804 14.7322C2.24688 14.2634 2.88276 14 3.5458 14C4.20884 14 4.84473 14.2634 5.31357 14.7322C5.78241 15.2011 6.0458 15.837 6.0458 16.5C6.0458 17.163 5.78241 17.7989 5.31357 18.2678C4.84473 18.7366 4.20884 19 3.5458 19C2.88276 19 2.24688 18.7366 1.77804 18.2678C1.3092 17.7989 1.0458 17.163 1.0458 16.5Z" />
               </svg>
 
             </button>
@@ -332,7 +371,8 @@
               <span class="height-label">Height</span>
               <span class="height-label height-number" id="heightDisplay">0</span>
               <div class="height-vertical-slider-container">
-                <input type="range" id="heightSlider" min="0" max="40" value="0" class="styled-range height-vertical-range">
+                <input type="range" id="heightSlider" min="0" max="40" value="0"
+                  class="styled-range height-vertical-range">
               </div>
             </div>
           </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -35,6 +35,7 @@
         </button>
       </div>
       <div class="preview-viewport" id="previewContainer">
+        <video id="previewVideo" autoplay muted playsinline></video>
         <canvas id="previewCanvas"></canvas>
         <div id="previewMarker"></div>
       </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -97,37 +97,36 @@
             </div>
           </div>
 
-          <!-- Preview Button -->
-          <div class="preview-action-container">
-            <button id="previewPathBtn" class="action-btn">
-              <span class="btn-icon">
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <polygon points="5 3 19 12 5 21 5 3"></polygon>
-                </svg>
-              </span>
-              <span class="btn-text">PREVIEW PATH</span>
-            </button>
-          </div>
 
           <!-- Bottom Buttons -->
           <div id="bottomButtons">
-            <button id="prepareCancelBtn" class="action-btn action-btn-cancel">
-              <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-                <path
-                  d="M8 0C3.589 0 0 3.589 0 8C0 12.411 3.589 16 8 16C12.411 16 16 12.411 16 8C16 3.589 12.411 0 8 0ZM3 8C3 7.168 3.224 6.396 3.584 5.705L10.295 12.416C9.58866 12.7939 8.80103 12.9943 8 13C5.243 13 3 10.757 3 8ZM12.416 10.295L5.705 3.584C6.41134 3.20614 7.19897 3.00571 8 3C10.757 3 13 5.243 13 8C13 8.832 12.776 9.604 12.416 10.295Z" />
+            <button id="previewBtn" class="action-btn action-btn-prepare full-width-btn">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                xmlns="http://www.w3.org/2000/svg">
+                <path d="M5 3l14 9-14 9V3z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
               </svg>
-              <span class="btn-text">CANCEL</span>
+              <span class="btn-text">SIMULATE PATH</span>
             </button>
 
-            <button id="executeBtn" class="action-btn action-btn-execute" data-state="ready">
-              <span class="btn-icon">
-                <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+            <div class="bottom-btn-row">
+              <button id="prepareCancelBtn" class="action-btn action-btn-cancel half-width-btn">
+                <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
                   <path
-                    d="M10 0C15.523 0 20 4.477 20 10C20 15.523 15.523 20 10 20C4.477 20 0 15.523 0 10C0 4.477 4.477 0 10 0ZM10 13C9.73478 13 9.48043 13.1054 9.29289 13.2929C9.10536 13.4804 9 13.7348 9 14C9 14.2652 9.10536 14.5196 9.29289 14.7071C9.48043 14.8946 9.73478 15 10 15C10.2652 15 10.5196 14.8946 10.7071 14.7071C10.8946 14.5196 11 14.2652 11 14C11 13.7348 10.8946 13.4804 10.7071 13.2929C10.5196 13.1054 10.2652 13 10 13ZM10 4C9.75507 4.00003 9.51866 4.08996 9.33563 4.25272C9.15259 4.41547 9.03566 4.63975 9.007 4.883L9 5V11C9.00028 11.2549 9.09788 11.5 9.27285 11.6854C9.44782 11.8707 9.68695 11.9822 9.94139 11.9972C10.1958 12.0121 10.4464 11.9293 10.6418 11.7657C10.8373 11.6021 10.9629 11.3701 10.993 11.117L11 11V5C11 4.73478 10.8946 4.48043 10.7071 4.29289C10.5196 4.10536 10.2652 4 10 4Z" />
+                    d="M8 0C3.589 0 0 3.589 0 8C0 12.411 3.589 16 8 16C12.411 16 16 12.411 16 8C16 3.589 12.411 0 8 0ZM3 8C3 7.168 3.224 6.396 3.584 5.705L10.295 12.416C9.58866 12.7939 8.80103 12.9943 8 13C5.243 13 3 10.757 3 8ZM12.416 10.295L5.705 3.584C6.41134 3.20614 7.19897 3.00571 8 3C10.757 3 13 5.243 13 8C13 8.832 12.776 9.604 12.416 10.295Z" />
                 </svg>
-              </span>
-              <span class="btn-text">EXECUTE</span>
-            </button>
+                <span class="btn-text">CANCEL</span>
+              </button>
+
+              <button id="executeBtn" class="action-btn action-btn-execute half-width-btn" disabled>
+                <span class="btn-icon">
+                  <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M10 0C15.523 0 20 4.477 20 10C20 15.523 15.523 20 10 20C4.477 20 0 15.523 0 10C0 4.477 4.477 0 10 0ZM10 13C9.73478 13 9.48043 13.1054 9.29289 13.2928C9.10536 13.4804 9 13.7348 9 14C9 14.2652 9.10536 14.5196 9.29289 14.7071C9.48043 14.8946 9.73478 15 10 15C10.2652 15 10.5196 14.8946 10.7071 14.7071C10.8946 14.5196 11 14.2652 11 14C11 13.7348 10.8946 13.4804 10.7071 13.2928C10.5196 13.1054 10.2652 13 10 13ZM10 4C9.75507 4.00003 9.51866 4.08996 9.33563 4.25272C9.15259 4.41547 9.03566 4.63975 9.007 4.883L9 5V11C9.00028 11.2549 9.09788 11.5 9.27285 11.6854C9.44782 11.8707 9.68695 11.9822 9.94139 11.9972C10.1958 12.0121 10.4464 11.9293 10.6418 11.7657C10.8373 11.6021 10.9629 11.3701 10.993 11.117L11 11V5C11 4.73478 10.8946 4.48043 10.7071 4.29289C10.5196 4.10536 10.2652 4 10 4Z" />
+                  </svg>
+                </span>
+                <span class="btn-text">EXECUTE</span>
+              </button>
+            </div>
           </div>
 
         </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,24 +22,6 @@
 <body>
   <div id="app-scaler">
     <div id="overlay"></div>
-    <div id="previewPopup">
-      <div class="preview-header">
-        <div class="preview-info">
-          <h3>Simulation</h3>
-          <span id="previewTimeDisplay">Est. Time: -- s</span>
-        </div>
-        <button id="previewCloseBtn">
-          <svg width="24" height="24" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-            <path d="M18 6L6 18M6 6L18 18" stroke-linecap="round" stroke-linejoin="round" />
-          </svg>
-        </button>
-      </div>
-      <div class="preview-viewport" id="previewContainer">
-        <video id="previewVideo" autoplay muted playsinline></video>
-        <canvas id="previewCanvas"></canvas>
-        <div id="previewMarker"></div>
-      </div>
-    </div>
     <div id="preparePopup">
       <div class="prepare-header">
         <h2>Prepare Path</h2>
@@ -53,61 +35,70 @@
       <div class="prepare-body">
         <div class="control-group">
 
-          <!-- Speed Input - NO container -->
-          <div class="speed-input-wrapper">
-            <label for="speedInput" class="input-label">Robot Speed (mm/s)</label>
-            <div class="input-wrapper">
-              <input type="number" id="speedInput" class="styled-input" value="10" step="10" min="1" max="100"
-                placeholder="e.g. 10">
-            </div>
+          <div class="setting-row-wrapper">
+            <label for="speedInput" class="row-label">Robot Speed (mm/s)</label>
+            <input type="number" id="speedInput" class="row-input" value="10" step="10" min="1" max="100"
+              placeholder="10">
           </div>
 
-          <!-- Fill Shape Toggle Container -->
-          <div class="fill-toggle-container">
-            <span class="input-label">Fill Shape</span>
-            <div class="segment-control" style="width: 140px;">
+          <div class="setting-row-wrapper">
+            <span class="row-label">Fill Shape</span>
+            <div class="segment-control fill-control">
               <button id="fillOff" class="segment-btn active">Off</button>
               <button id="fillOn" class="segment-btn">On</button>
             </div>
           </div>
 
-          <!-- Accordion Panel (outside container) -->
           <div class="fill-accordion-container">
             <div id="fillSettingsPanel" class="fill-settings-panel">
               <div class="fill-settings-inner">
 
-                <!-- Raster Pattern Section -->
-                <div class="raster-pattern-section">
-                  <label class="fill-setting-label">Raster Pattern</label>
-                  <div class="segment-control raster-pattern-control">
-                    <button id="rasterA" class="segment-btn active">Line</button>
-                    <button id="rasterB" class="segment-btn">Spiral</button>
+                <div class="settings-group-container">
+                  <div class="setting-row-wrapper secondary-wrapper">
+                    <label class="row-label">Raster Pattern</label>
+                    <div class="segment-control raster-control">
+                      <button id="rasterA" class="segment-btn active">Line</button>
+                      <button id="rasterB" class="segment-btn">Spiral</button>
+                    </div>
+                  </div>
+
+                  <div class="setting-row-wrapper secondary-wrapper">
+                    <label for="densityRaster" class="row-label">Density</label>
+                    <input type="number" id="densityRaster" class="row-input" value="10" step="1" min="1" max="20"
+                      placeholder="10">
                   </div>
                 </div>
 
-                <!-- Density Section -->
-                <div class="density-section">
-                  <div class="density-wrapper">
-                    <label for="densityRaster" class="fill-setting-label">Density:</label>
-                    <input type="number" id="densityRaster" class="styled-input-density" value="10" step="1" min="1"
-                      max="20" placeholder="10">
+              </div>
+            </div>
+          </div>
+
+          <div class="preview-action-container">
+            <div class="setting-row-wrapper preview-wrapper">
+              <span class="row-label">Preview Path</span>
+              <div class="segment-control preview-control">
+                <button id="previewOff" class="segment-btn active">OFF</button>
+                <button id="previewOn" class="segment-btn">ON</button>
+              </div>
+            </div>
+
+            <div id="previewInfoPanel" class="preview-info-panel">
+              <div class="preview-info-inner">
+                <div class="preview-duration-row">
+                  <span class="preview-duration-label">Estimated Duration:</span>
+                  <span id="previewDuration" class="preview-duration-value">--</span>
+                </div>
+                <div class="preview-info-row">
+                  <div class="preview-info-icon">i</div>
+                  <div class="preview-info-text">
+                    Yellow line indicates the positioning of the planned path. Orange marker indicates the movement and speed of the end effector.
                   </div>
                 </div>
               </div>
             </div>
           </div>
 
-
-          <!-- Bottom Buttons -->
           <div id="bottomButtons">
-            <button id="previewBtn" class="action-btn action-btn-prepare full-width-btn">
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                xmlns="http://www.w3.org/2000/svg">
-                <path d="M5 3l14 9-14 9V3z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-              </svg>
-              <span class="btn-text">SIMULATE PATH</span>
-            </button>
-
             <div class="bottom-btn-row">
               <button id="prepareCancelBtn" class="action-btn action-btn-cancel half-width-btn">
                 <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
@@ -145,9 +136,7 @@
       <div class="settings-body">
         <div class="settings-sidebar">
           <button class="sidebar-btn active" data-target="general-settings">General</button>
-          <!-- <button class="sidebar-btn" data-target="robot-settings">Robot</button> -->
           <button class="sidebar-btn" data-target="camera-settings">Camera</button>
-          <!-- <button class="sidebar-btn" data-target="laser-settings">Laser</button> -->
         </div>
         <div class="settings-main">
           <div id="general-settings" class="settings-panel active">
@@ -179,9 +168,6 @@
               </div>
             </div>
           </div>
-          <!-- <div id="robot-settings" class="settings-panel">
-            <h3>Robot Settings</h3>
-          </div> -->
           <div id="camera-settings" class="settings-panel">
             <h3>Camera Settings</h3>
             <div class="setting-item">
@@ -195,11 +181,7 @@
                 <span class="switch-label">On</span>
               </div>
             </div>
-            <!-- <button id="save-view" class="btn-text" data-state="ready">SAVE</button> -->
           </div>
-          <!-- <div id="laser-settings" class="settings-panel">
-            <h3>Laser Settings</h3>
-          </div> -->
         </div>
       </div>
     </div>
@@ -436,8 +418,10 @@
     </div>
     <div id="viewport">
       <canvas id="canvas"></canvas>
+      <canvas id="previewOverlay"></canvas>
       <video id="video"></video>
       <div id="robot-marker"></div>
+      <div id="preview-marker"></div>
     </div>
   </div>
 </body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -418,6 +418,17 @@
       </div>
     </div>
     <div id="viewport">
+      <div id="thermal-gradient-legend" class="thermal-ui hidden">
+        <div class="legend-core">
+          <div class="gradient-bar"></div>
+          <div class="gradient-labels">
+            <span>100</span>
+            <span>60</span>
+            <span>20</span>
+          </div>
+        </div>
+        <div class="legend-unit">°C</div>
+      </div>
       <div id="zoom-wrapper">
         <canvas id="canvas"></canvas>
         <canvas id="previewOverlay"></canvas>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -418,7 +418,7 @@
       </div>
     </div>
     <div id="viewport">
-      <div id="thermal-gradient-legend" class="thermal-ui hidden">
+      <div id="thermal-gradient-legend" class="hidden">
         <div class="legend-core">
           <div class="gradient-bar"></div>
           <div class="gradient-labels">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -352,7 +352,7 @@
             </button>
             <div class="height-container">
               <span class="height-label">Height</span>
-              <span class="height-label height-number" id="heightDisplay">0</span>
+              <span class="height-label height-number" id="heightDisplay">0 CM</span>
               <div class="height-vertical-slider-container">
                 <input type="range" id="heightSlider" min="0" max="40" value="0"
                   class="styled-range height-vertical-range">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -91,7 +91,7 @@
                 <div class="preview-info-row">
                   <div class="preview-info-icon">i</div>
                   <div class="preview-info-text">
-                    Yellow line indicates the positioning of the planned path. Orange marker indicates the movement and speed of the end effector.
+                    Yellow line indicates the path to execute. Orange marker indicates the planned speed of the end effector. Green marker is active robot position.
                   </div>
                 </div>
               </div>

--- a/frontend/src/core/AppController.ts
+++ b/frontend/src/core/AppController.ts
@@ -479,7 +479,7 @@ class AppController {
         }
 
         if (state.path_preview) {
-            this.previewManager.handlePathFromWebSocket(state.path_preview);
+            this.previewManager.handlePathFromWebSocket(state.path_preview, state.preview_duration);
         }
 
         // --- Thermal / heat data ---

--- a/frontend/src/core/AppController.ts
+++ b/frontend/src/core/AppController.ts
@@ -487,11 +487,6 @@ class AppController {
                 zoomWrapper.style.transform = `scale(${zoomLevel})`;
             }
 
-            if (zoomLevel > 1) {
-                this.ui.viewport.style.overflow = 'auto';
-            } else {
-                this.ui.viewport.style.overflow = 'hidden';
-            }
 
 
         }, { passive: false });
@@ -530,12 +525,6 @@ class AppController {
 
                 zoomWrapper.style.transform = `scale(${zoomLevel})`;
 
-                // show scrollbars when zoomed in, hide at default
-                if (zoomLevel > 1) {
-                    this.ui.viewport.style.overflow = 'auto';
-                } else {
-                    this.ui.viewport.style.overflow = 'hidden';
-                }
             }
         }, { passive: false });
 

--- a/frontend/src/core/AppController.ts
+++ b/frontend/src/core/AppController.ts
@@ -212,7 +212,7 @@ class AppController {
             () => this.executionManager.onShapeComplete(),
             () => this.toolHandler.updateFixturesButtonState(),
             () => this.toolHandler.updateThermalButtonState(),
-            () => { this.ui.resetHeatAreaBtn.disabled = false; },
+            () => { this.ui.resetHeatAreaBtn.disabled = false; this.ui.heatLegend.classList.remove('hidden'); },
         );
 
         this.canvasManager.onShapeModified = () => {
@@ -247,24 +247,24 @@ class AppController {
      * Ensures sub-systems update in the correct order to avoid layout thrashing.
      */
     private handleResize(): void {
-        // 1. Layout Manager: Calculate new panel positions/sizes
+        //Layout Manager: Calculate new panel positions/sizes
         this.settingsManager.handleResize();
 
-        // 2. Get authoritative viewport dimensions
+        //Get authoritative viewport dimensions
         const w = this.ui.viewport.offsetWidth;
         const h = this.ui.viewport.offsetHeight;
 
-        // 3. Preview Manager: Resize overlay and re-project path
+        //Preview Manager: Resize overlay and re-project path
         this.previewManager.updateOverlaySize();
 
-        // 4. Canvas Manager: Scale fabric canvas and objects
+        //Canvas Manager: Scale fabric canvas and objects
         if (this.canvasManager) {
-            // Check against internal canvas dimensions to prevent unnecessary updates
+            //Check against internal canvas dimensions to prevent unnecessary updates
             if (this.ui.canvas.width !== w || this.ui.canvas.height !== h) {
                 this.canvasManager.updateCanvasSize(w, h);
             }
         } else {
-            // If CM doesn't exist yet, ensure the raw canvas element matches viewport
+            //If CM doesn't exist yet, ensure the raw canvas element matches viewport
             this.ui.canvas.width = w;
             this.ui.canvas.height = h;
         }
@@ -352,8 +352,12 @@ class AppController {
         });
         this.ui.resetHeatAreaBtn.addEventListener('click', async () => {
             if (!this.canvasManager) return;
-            this.ui.resetHeatAreaBtn.disabled = true;
-            try { await this.canvasManager.resetHeatArea(); }
+            try { 
+                await this.canvasManager.resetHeatArea();
+                this.ui.resetHeatAreaBtn.disabled = true;
+                this.ui.heatLegend.classList.add('hidden')
+
+             }
             catch (e) { console.error(e); this.ui.resetHeatAreaBtn.disabled = false; }
         });
         this.ui.clearMarkersBtn.addEventListener('click', async () => {
@@ -361,6 +365,7 @@ class AppController {
             this.canvasManager.clearMarkers();
             await this.canvasManager.submitHeatMarkers(this.canvasManager.getHeatMarkersInVideoSpace());
         });
+
 
         // --- Fixture brushes & actions ---
         this.ui.roundBrushBtn.addEventListener('click', () => this.toolHandler.handleBrushSelection('round'));

--- a/frontend/src/core/AppController.ts
+++ b/frontend/src/core/AppController.ts
@@ -104,6 +104,7 @@ class AppController {
             this.state,
             getCM,
             () => this.toolHandler.updateDrawButtonState(),
+            () => this.previewManager.openPreview(),
         );
 
         this.settingsManager = new SettingsManager(
@@ -231,7 +232,6 @@ class AppController {
         this.ui.prepareCloseBtn.addEventListener('click', () => this.ui.preparePopup.classList.remove('active'));
         this.ui.prepareCancelBtn.addEventListener('click', () => this.ui.preparePopup.classList.remove('active'));
 
-        this.ui.previewBtn.addEventListener('click', () => this.previewManager.openPreview());
         this.ui.previewCloseBtn.addEventListener('click', () => this.previewManager.closePreview());
 
         //Live preview window refresh
@@ -344,7 +344,8 @@ class AppController {
         this.ui.canvas.addEventListener('mouseup', () => setTimeout(() => this.toolHandler.updateDrawButtonState(), 50));
         this.ui.canvas.addEventListener('touchend', () => setTimeout(() => this.toolHandler.updateDrawButtonState(), 50));
 
-        // --- Execution actions ---
+        // --- Execution actions ---;
+        this.ui.previewBtn.addEventListener('click', () => this.executionManager.previewPath());
         this.ui.executeBtn.addEventListener('click', () => this.executionManager.executePath());
         this.ui.clearBtn.addEventListener('click', () => this.executionManager.clearDrawing());
 
@@ -435,6 +436,10 @@ class AppController {
                 this.ui.robotMarker.style.top = `${(state.laserY / vh) * ch}px`;
                 this.ui.robotMarker.style.display = 'block';
             }
+        }
+
+        if (state.path_preview) {
+            this.previewManager.handlePathFromWebSocket(state.path_preview);
         }
 
         // --- Thermal / heat data ---

--- a/frontend/src/core/AppController.ts
+++ b/frontend/src/core/AppController.ts
@@ -215,6 +215,16 @@ class AppController {
             () => { this.ui.resetHeatAreaBtn.disabled = false; },
         );
 
+        this.canvasManager.onShapeModified = () => {
+            if (this.ui.previewToggleOn.classList.contains('active')) {
+                // The preview window is currently open, so silently refresh the data!
+                this.previewManager.refreshPreview();
+            } else {
+                // The preview window is closed. Invalidate old data to wait for new request
+                this.executionManager.onShapeComplete(); 
+            }
+        };
+
         this.toolHandler.updateDrawButtonState();
         this.toolHandler.updateFixturesButtonState();
         this.toolHandler.updateThermalButtonState();

--- a/frontend/src/core/AppController.ts
+++ b/frontend/src/core/AppController.ts
@@ -154,6 +154,19 @@ class AppController {
 
         // Restore persisted layout positions
         this.settingsManager.restoreLayoutPositions();
+
+        //Save robot height to localStorage to keep it from shifting on page reload
+        const savedHeight = localStorage.getItem('robot_height');
+        if (savedHeight) {
+            const heightVal = parseInt(savedHeight);
+            if (!isNaN(heightVal)) {
+                //Update the Slider UI
+                this.ui.heightSlider.value = savedHeight;
+                //Update the Text Display
+                this.ui.heightDisplay.textContent = savedHeight;
+                //TODO: May need to send a wshandler.updateState to sync
+            }
+        }
     }
 
     private setMessage(str: string): void {
@@ -363,7 +376,11 @@ class AppController {
         this.ui.heightSlider.addEventListener('input', () => {
             const heightValue = parseInt(this.ui.heightSlider.value);
             this.ui.heightDisplay.textContent = String(heightValue);
-            //console.log('Sending height:', heightValue);
+            
+            //Save to local storage
+            localStorage.setItem('robot_height', String(heightValue));
+            
+            //Send to backend
             this.wsHandler.updateState({ height: heightValue });
         });
 

--- a/frontend/src/core/AppController.ts
+++ b/frontend/src/core/AppController.ts
@@ -348,6 +348,9 @@ class AppController {
         this.ui.previewBtn.addEventListener('click', () => this.executionManager.previewPath());
         this.ui.executeBtn.addEventListener('click', () => this.executionManager.executePath());
         this.ui.clearBtn.addEventListener('click', () => this.executionManager.clearDrawing());
+        this.ui.clearBtn.addEventListener('click', () => {
+            this.ui.previewBtn.disabled = true;
+        });
 
         // --- Fill / Raster settings ---
         const updateFillState = (isEnabled: boolean) => {

--- a/frontend/src/core/AppController.ts
+++ b/frontend/src/core/AppController.ts
@@ -237,7 +237,7 @@ class AppController {
         //Live preview window refresh
         const refreshPreview = () => {
             if (this.ui.previewPopup.classList.contains('active')) {
-                 this.previewManager.updatePreviewData();
+                this.previewManager.updatePreviewData();
             }
         };
 
@@ -246,8 +246,8 @@ class AppController {
 
         let debounceTimer: any;
         this.ui.rasterDensityInput.addEventListener('input', () => {
-             clearTimeout(debounceTimer);
-             debounceTimer = setTimeout(refreshPreview, 500);
+            clearTimeout(debounceTimer);
+            debounceTimer = setTimeout(refreshPreview, 500);
         });
 
         // Clicking the background overlay closes whichever modal is open
@@ -356,17 +356,19 @@ class AppController {
                 this.ui.fillOnBtn.classList.add('active');
                 this.ui.fillOffBtn.classList.remove('active');
                 this.ui.fillSettingsPanel.classList.add('open');
+                this.ui.fillSettingsPanel.parentElement?.classList.add('has-open-panel');
             } else {
                 this.ui.fillOnBtn.classList.remove('active');
                 this.ui.fillOffBtn.classList.add('active');
                 this.ui.fillSettingsPanel.classList.remove('open');
+                this.ui.fillSettingsPanel.parentElement?.classList.remove('has-open-panel');
             }
             refreshPreview();
         };
 
         this.ui.fillOnBtn.addEventListener('click', () => updateFillState(true));
         this.ui.fillOffBtn.addEventListener('click', () => updateFillState(false));
-        
+
         // Raster pattern buttons are mutually exclusive
         this.ui.rasterBtnA.addEventListener('click', () => {
             this.ui.rasterBtnA.classList.add('active');

--- a/frontend/src/core/AppController.ts
+++ b/frontend/src/core/AppController.ts
@@ -11,6 +11,7 @@ import { ModeManager } from '../features/settings/ModeManager';
 import { ToolHandler } from '../features/drawing/ToolHandler';
 import { ExecutionManager } from '../features/drawing/ExecutionManager';
 import { SettingsManager } from '../features/settings/SettingsManager';
+import { PreviewManager } from '../features/drawing/PreviewManager';
 
 // ---------------------------------------------------------------------------
 // Global type augmentation – MediaMTXWebRTCReader lives on window at runtime
@@ -58,6 +59,7 @@ class AppController {
     private readonly toolHandler: ToolHandler;
     private readonly executionManager: ExecutionManager;
     private readonly settingsManager: SettingsManager;
+    private readonly previewManager: PreviewManager;
 
     // ---------------------------------------------------------------
     // Late-initialised (created once the video track arrives)
@@ -111,6 +113,8 @@ class AppController {
             this.hardware,
             () => this.toolHandler.updateDrawButtonState(),
         );
+
+        this.previewManager = new PreviewManager(this.ui, this.state, getCM);
 
         // TODO: Expose on window for quick console access during development
         // TODO: REMOVE BEFORE SHIPPING
@@ -227,6 +231,25 @@ class AppController {
         this.ui.prepareCloseBtn.addEventListener('click', () => this.ui.preparePopup.classList.remove('active'));
         this.ui.prepareCancelBtn.addEventListener('click', () => this.ui.preparePopup.classList.remove('active'));
 
+        this.ui.previewBtn.addEventListener('click', () => this.previewManager.openPreview());
+        this.ui.previewCloseBtn.addEventListener('click', () => this.previewManager.closePreview());
+
+        //Live preview window refresh
+        const refreshPreview = () => {
+            if (this.ui.previewPopup.classList.contains('active')) {
+                 this.previewManager.updatePreviewData();
+            }
+        };
+
+        this.ui.rasterBtnA.addEventListener('click', refreshPreview);
+        this.ui.rasterBtnB.addEventListener('click', refreshPreview);
+
+        let debounceTimer: any;
+        this.ui.rasterDensityInput.addEventListener('input', () => {
+             clearTimeout(debounceTimer);
+             debounceTimer = setTimeout(refreshPreview, 500);
+        });
+
         // Clicking the background overlay closes whichever modal is open
         this.ui.overlay.addEventListener('click', () => {
             if (this.ui.settingsPopup.classList.contains('active')) this.settingsManager.closeSettings();
@@ -326,12 +349,24 @@ class AppController {
         this.ui.clearBtn.addEventListener('click', () => this.executionManager.clearDrawing());
 
         // --- Fill / Raster settings ---
-        this.ui.fillAccordionToggle.addEventListener('click', () => {
-            this.ui.fillSettingsPanel.classList.toggle('open');
-            this.ui.fillAccordionToggle.classList.toggle('active');
-            this.state.fillEnabled = this.ui.fillAccordionToggle.classList.contains('active');
-        });
+        const updateFillState = (isEnabled: boolean) => {
+            this.state.fillEnabled = isEnabled;
 
+            if (isEnabled) {
+                this.ui.fillOnBtn.classList.add('active');
+                this.ui.fillOffBtn.classList.remove('active');
+                this.ui.fillSettingsPanel.classList.add('open');
+            } else {
+                this.ui.fillOnBtn.classList.remove('active');
+                this.ui.fillOffBtn.classList.add('active');
+                this.ui.fillSettingsPanel.classList.remove('open');
+            }
+            refreshPreview();
+        };
+
+        this.ui.fillOnBtn.addEventListener('click', () => updateFillState(true));
+        this.ui.fillOffBtn.addEventListener('click', () => updateFillState(false));
+        
         // Raster pattern buttons are mutually exclusive
         this.ui.rasterBtnA.addEventListener('click', () => {
             this.ui.rasterBtnA.classList.add('active');
@@ -364,6 +399,9 @@ class AppController {
         // --- Window resize ---
         window.addEventListener('resize', () => {
             this.settingsManager.handleResize();
+            if (this.ui.previewPopup.classList.contains('active')) {
+                this.previewManager.updatePreviewData();
+            }
             if (this.canvasManager) {
                 const w = this.ui.viewport.offsetWidth;
                 const h = this.ui.viewport.offsetHeight;

--- a/frontend/src/core/UIRegistry.ts
+++ b/frontend/src/core/UIRegistry.ts
@@ -18,25 +18,25 @@ export interface UIRegistry {
     overlay: HTMLElement;
     settingsPopup: HTMLElement;
     preparePopup: HTMLElement;
-    previewPopup: HTMLElement;
-    previewTimeDisplay: HTMLElement;
-    previewCanvas: HTMLCanvasElement;
-    previewVideo: HTMLVideoElement;
 
     // --- Action Buttons ---
     settingsBtn: HTMLButtonElement;
     settingsCloseBtn: HTMLButtonElement;
-    
+
     // Top panel button that opens the popup
     prepareBtn: HTMLButtonElement;
-    
+
     // Popup buttons
     prepareCloseBtn: HTMLButtonElement;
     prepareCancelBtn: HTMLButtonElement;
-    previewBtn: HTMLButtonElement; 
     executeBtn: HTMLButtonElement;
-    previewCloseBtn: HTMLButtonElement;
     clearBtn: HTMLButtonElement;
+    previewOverlay: HTMLCanvasElement;
+    previewToggleOn: HTMLButtonElement;
+    previewToggleOff: HTMLButtonElement;
+    previewInfoPanel: HTMLElement;
+    previewDuration: HTMLElement;
+    previewMarker: HTMLElement;
 
     // --- Hardware Controls (Robot / Laser) ---
     robotBtn: HTMLButtonElement;
@@ -63,7 +63,6 @@ export interface UIRegistry {
 
     // --- Visual Markers ---
     robotMarker: HTMLElement;
-    previewMarker: HTMLElement;
 
     // --- Shape Drawing Tools ---
     penBtn: HTMLButtonElement;
@@ -115,103 +114,101 @@ export interface UIRegistry {
 export function createUIRegistry(): UIRegistry {
     return {
         // Core Viewport
-        viewport:  document.getElementById('viewport')               as HTMLElement,
-        video:     document.getElementById('video')                  as HTMLVideoElement,
-        canvas:    document.getElementById('canvas')                 as HTMLCanvasElement,
-        ctx:       (document.getElementById('canvas') as HTMLCanvasElement).getContext('2d')!,
+        viewport: document.getElementById('viewport') as HTMLElement,
+        video: document.getElementById('video') as HTMLVideoElement,
+        canvas: document.getElementById('canvas') as HTMLCanvasElement,
+        ctx: (document.getElementById('canvas') as HTMLCanvasElement).getContext('2d')!,
 
         // Modals & Overlays
-        overlay:        document.getElementById('overlay')           as HTMLElement,
-        settingsPopup:  document.getElementById('settingsPopup')     as HTMLElement,
-        preparePopup:   document.getElementById('preparePopup')      as HTMLElement,
-        previewPopup: document.getElementById('previewPopup') as HTMLElement,
-        previewCanvas: document.getElementById('previewCanvas') as HTMLCanvasElement,
-        previewTimeDisplay: document.getElementById('previewTimeDisplay') as HTMLElement,
-        previewVideo: document.getElementById('previewVideo') as HTMLVideoElement,
+        overlay: document.getElementById('overlay') as HTMLElement,
+        settingsPopup: document.getElementById('settingsPopup') as HTMLElement,
+        preparePopup: document.getElementById('preparePopup') as HTMLElement,
 
         // Action Buttons
-        settingsBtn:      document.getElementById('settingsBtn')      as HTMLButtonElement,
+        settingsBtn: document.getElementById('settingsBtn') as HTMLButtonElement,
         settingsCloseBtn: document.getElementById('settingsCloseBtn') as HTMLButtonElement,
-        
-        prepareBtn:       document.getElementById('prepareBtn')       as HTMLButtonElement,
-        prepareCloseBtn:  document.getElementById('prepareCloseBtn')  as HTMLButtonElement,
+
+        prepareBtn: document.getElementById('prepareBtn') as HTMLButtonElement,
+        prepareCloseBtn: document.getElementById('prepareCloseBtn') as HTMLButtonElement,
         prepareCancelBtn: document.getElementById('prepareCancelBtn') as HTMLButtonElement,
-        previewBtn:       document.getElementById('previewBtn')       as HTMLButtonElement, 
-        executeBtn:       document.getElementById('executeBtn')       as HTMLButtonElement,
-        
-        previewCloseBtn:  document.getElementById('previewCloseBtn')  as HTMLButtonElement,
-        clearBtn:         document.getElementById('clearBtn')         as HTMLButtonElement,
+        executeBtn: document.getElementById('executeBtn') as HTMLButtonElement,
+        previewOverlay: document.getElementById('previewOverlay') as HTMLCanvasElement,
+        previewToggleOn: document.getElementById('previewOn') as HTMLButtonElement,
+        previewToggleOff: document.getElementById('previewOff') as HTMLButtonElement,
+        previewInfoPanel: document.getElementById('previewInfoPanel') as HTMLElement,
+        previewDuration: document.getElementById('previewDuration') as HTMLElement,
+        previewMarker: document.getElementById('robot-marker') as HTMLElement,
+        clearBtn: document.getElementById('clearBtn') as HTMLButtonElement,
 
         // Hardware Controls
-        robotBtn: document.getElementById('robot-toggle-container')  as HTMLButtonElement,
-        laserBtn: document.getElementById('laser-toggle-container')  as HTMLButtonElement,
+        robotBtn: document.getElementById('robot-toggle-container') as HTMLButtonElement,
+        laserBtn: document.getElementById('laser-toggle-container') as HTMLButtonElement,
 
         // View & Mode Toggles
-        processingModeSwitch:   document.getElementById('processing-mode')         as HTMLInputElement,
-        transformedModeSwitch:  document.getElementById('transformed-view-mode')   as HTMLInputElement,
-        saveView:               document.getElementById('save-view')               as HTMLInputElement,
-        layoutTopBtn:           document.getElementById('layout-top')              as HTMLButtonElement,
-        layoutBottomBtn:        document.getElementById('layout-bottom')           as HTMLButtonElement,
-        layoutLeftBtn:          document.getElementById('layout-left')             as HTMLButtonElement,
-        layoutRightBtn:         document.getElementById('layout-right')            as HTMLButtonElement,
+        processingModeSwitch: document.getElementById('processing-mode') as HTMLInputElement,
+        transformedModeSwitch: document.getElementById('transformed-view-mode') as HTMLInputElement,
+        saveView: document.getElementById('save-view') as HTMLInputElement,
+        layoutTopBtn: document.getElementById('layout-top') as HTMLButtonElement,
+        layoutBottomBtn: document.getElementById('layout-bottom') as HTMLButtonElement,
+        layoutLeftBtn: document.getElementById('layout-left') as HTMLButtonElement,
+        layoutRightBtn: document.getElementById('layout-right') as HTMLButtonElement,
 
         // Input Fields
         speedInput: document.getElementById('speedInput') as HTMLInputElement,
 
         // Element Groups
-        batchUiElements:  document.querySelectorAll('.batch-ui'),
-        realTimeUIElements:  document.querySelectorAll('.real-time-ui'),
-        toggleButtons:    document.querySelectorAll('#middle-icon-section .icon-btn') as NodeListOf<HTMLButtonElement>,
-        sidebarButtons:   document.querySelectorAll('.settings-sidebar .sidebar-btn') as NodeListOf<HTMLButtonElement>,
-        settingsPanels:   document.querySelectorAll('.settings-main .settings-panel') as NodeListOf<HTMLElement>,
+        batchUiElements: document.querySelectorAll('.batch-ui'),
+        realTimeUIElements: document.querySelectorAll('.real-time-ui'),
+        toggleButtons: document.querySelectorAll('#middle-icon-section .icon-btn') as NodeListOf<HTMLButtonElement>,
+        sidebarButtons: document.querySelectorAll('.settings-sidebar .sidebar-btn') as NodeListOf<HTMLButtonElement>,
+        settingsPanels: document.querySelectorAll('.settings-main .settings-panel') as NodeListOf<HTMLElement>,
 
         // Visual Markers
         robotMarker: document.getElementById('robot-marker') as HTMLElement,
-        previewMarker: document.getElementById('previewMarker') as HTMLElement,
 
         // Shape Drawing Tools
-        penBtn:          document.getElementById('penBtn')          as HTMLButtonElement,
-        realTimePen:     document.getElementById('realTimePen')     as HTMLButtonElement,
-        squareBtn:       document.getElementById('squareBtn')       as HTMLButtonElement,
-        circleBtn:       document.getElementById('circleBtn')       as HTMLButtonElement,
-        triangleBtn:     document.getElementById('triangleBtn')     as HTMLButtonElement,
-        lineBtn:         document.getElementById('lineBtn')         as HTMLButtonElement,
-        markerBtn:       document.getElementById('markerBtn')       as HTMLButtonElement,
+        penBtn: document.getElementById('penBtn') as HTMLButtonElement,
+        realTimePen: document.getElementById('realTimePen') as HTMLButtonElement,
+        squareBtn: document.getElementById('squareBtn') as HTMLButtonElement,
+        circleBtn: document.getElementById('circleBtn') as HTMLButtonElement,
+        triangleBtn: document.getElementById('triangleBtn') as HTMLButtonElement,
+        lineBtn: document.getElementById('lineBtn') as HTMLButtonElement,
+        markerBtn: document.getElementById('markerBtn') as HTMLButtonElement,
         clearMarkersBtn: document.getElementById('clearMarkersBtn') as HTMLButtonElement,
 
         // Raster / Fill Settings
         fillOffBtn: document.getElementById('fillOff') as HTMLButtonElement,
-        fillOnBtn:  document.getElementById('fillOn')  as HTMLButtonElement,
-        fillSettingsPanel:   document.getElementById('fillSettingsPanel')   as HTMLElement,
-        rasterBtnA:          document.getElementById('rasterA')            as HTMLButtonElement,
-        rasterBtnB:          document.getElementById('rasterB')            as HTMLButtonElement,
-        rasterDensityInput:  document.getElementById('densityRaster')      as HTMLInputElement,
+        fillOnBtn: document.getElementById('fillOn') as HTMLButtonElement,
+        fillSettingsPanel: document.getElementById('fillSettingsPanel') as HTMLElement,
+        rasterBtnA: document.getElementById('rasterA') as HTMLButtonElement,
+        rasterBtnB: document.getElementById('rasterB') as HTMLButtonElement,
+        rasterDensityInput: document.getElementById('densityRaster') as HTMLInputElement,
 
         // Virtual Fixtures
-        fixturesTools:      document.getElementById('fixtures-tools')    as HTMLElement,
-        drawingTools:       document.getElementById('drawing-tools')     as HTMLElement,
-        thermalTools:       document.getElementById('thermal-tools')     as HTMLElement,
-        roundBrushBtn:      document.getElementById('roundBrushBtn')     as HTMLButtonElement,
-        squareBrushBtn:     document.getElementById('squareBrushBtn')    as HTMLButtonElement,
-        brushSizeSlider:    document.getElementById('brushSizeSlider')   as HTMLInputElement,
-        clearBoundaryBtn:   document.getElementById('clearBoundaryBtn')  as HTMLButtonElement,
-        applyFixturesBtn:   document.getElementById('applyFixturesBtn')  as HTMLButtonElement,
-        eraserBrushBtn:     document.getElementById('eraserBtn')         as HTMLButtonElement,
+        fixturesTools: document.getElementById('fixtures-tools') as HTMLElement,
+        drawingTools: document.getElementById('drawing-tools') as HTMLElement,
+        thermalTools: document.getElementById('thermal-tools') as HTMLElement,
+        roundBrushBtn: document.getElementById('roundBrushBtn') as HTMLButtonElement,
+        squareBrushBtn: document.getElementById('squareBrushBtn') as HTMLButtonElement,
+        brushSizeSlider: document.getElementById('brushSizeSlider') as HTMLInputElement,
+        clearBoundaryBtn: document.getElementById('clearBoundaryBtn') as HTMLButtonElement,
+        applyFixturesBtn: document.getElementById('applyFixturesBtn') as HTMLButtonElement,
+        eraserBrushBtn: document.getElementById('eraserBtn') as HTMLButtonElement,
 
         fixturesUiElements: document.querySelectorAll('.fixtures-ui-only'),
-        drawingUiElements:  document.querySelectorAll('.drawing-ui-only'),
-        thermalUiElements:  document.querySelectorAll('.thermal-ui'),
+        drawingUiElements: document.querySelectorAll('.drawing-ui-only'),
+        thermalUiElements: document.querySelectorAll('.thermal-ui'),
 
         // Thermal Data
         maxHeatDisplay: document.getElementById('max-heat-display') as HTMLElement,
-        heatAreaBtn:        document.getElementById('heatAreaBtn')         as HTMLButtonElement,
-        resetHeatAreaBtn:   document.getElementById('resetHeatAreaBtn')    as HTMLButtonElement,
+        heatAreaBtn: document.getElementById('heatAreaBtn') as HTMLButtonElement,
+        resetHeatAreaBtn: document.getElementById('resetHeatAreaBtn') as HTMLButtonElement,
 
         // Main Mode Switchers
         modeButtons: document.querySelectorAll('.mode-btn'),
 
         // Universal UI Elements
-        heightSlider:       document.getElementById('heightSlider')      as HTMLInputElement,
-        heightDisplay:      document.getElementById('heightDisplay')     as HTMLElement,
+        heightSlider: document.getElementById('heightSlider') as HTMLInputElement,
+        heightDisplay: document.getElementById('heightDisplay') as HTMLElement,
     };
 }

--- a/frontend/src/core/UIRegistry.ts
+++ b/frontend/src/core/UIRegistry.ts
@@ -137,7 +137,7 @@ export function createUIRegistry(): UIRegistry {
         previewToggleOff: document.getElementById('previewOff') as HTMLButtonElement,
         previewInfoPanel: document.getElementById('previewInfoPanel') as HTMLElement,
         previewDuration: document.getElementById('previewDuration') as HTMLElement,
-        previewMarker: document.getElementById('robot-marker') as HTMLElement,
+        previewMarker: document.getElementById('preview-marker') as HTMLElement,
         clearBtn: document.getElementById('clearBtn') as HTMLButtonElement,
 
         // Hardware Controls

--- a/frontend/src/core/UIRegistry.ts
+++ b/frontend/src/core/UIRegistry.ts
@@ -19,6 +19,9 @@ export interface UIRegistry {
     overlay: HTMLElement;
     settingsPopup: HTMLElement;
     preparePopup: HTMLElement;
+    previewPopup: HTMLElement;
+    previewTimeDisplay: HTMLElement;
+    previewCanvas: HTMLCanvasElement;
 
     // --- Action Buttons ---
     settingsBtn: HTMLButtonElement;
@@ -26,6 +29,8 @@ export interface UIRegistry {
     prepareBtn: HTMLButtonElement;
     prepareCloseBtn: HTMLButtonElement;
     prepareCancelBtn: HTMLButtonElement;
+    previewBtn: HTMLButtonElement;
+    previewCloseBtn: HTMLButtonElement;
     executeBtn: HTMLButtonElement;
     clearBtn: HTMLButtonElement;
 
@@ -54,6 +59,7 @@ export interface UIRegistry {
 
     // --- Visual Markers ---
     robotMarker: HTMLElement;
+    previewMarker: HTMLElement;
 
     // --- Shape Drawing Tools ---
     penBtn: HTMLButtonElement;
@@ -66,7 +72,8 @@ export interface UIRegistry {
     clearMarkersBtn: HTMLButtonElement;
 
     // --- Raster / Fill Settings ---
-    fillAccordionToggle: HTMLButtonElement;
+    fillOffBtn: HTMLButtonElement;
+    fillOnBtn: HTMLButtonElement;
     fillSettingsPanel: HTMLElement;
     rasterBtnA: HTMLButtonElement;
     rasterBtnB: HTMLButtonElement;
@@ -115,8 +122,11 @@ export function createUIRegistry(): UIRegistry {
 
         // Modals & Overlays
         overlay:        document.getElementById('overlay')           as HTMLElement,
-        settingsPopup:  document.getElementById('settingsPopup')    as HTMLElement,
-        preparePopup:   document.getElementById('preparePopup')     as HTMLElement,
+        settingsPopup:  document.getElementById('settingsPopup')     as HTMLElement,
+        preparePopup:   document.getElementById('preparePopup')      as HTMLElement,
+        previewPopup: document.getElementById('previewPopup') as HTMLElement,
+        previewCanvas: document.getElementById('previewCanvas') as HTMLCanvasElement,
+        previewTimeDisplay: document.getElementById('previewTimeDisplay') as HTMLElement,
 
         // Action Buttons
         settingsBtn:      document.getElementById('settingsBtn')      as HTMLButtonElement,
@@ -124,6 +134,8 @@ export function createUIRegistry(): UIRegistry {
         prepareBtn:       document.getElementById('prepareBtn')       as HTMLButtonElement,
         prepareCloseBtn:  document.getElementById('prepareCloseBtn')  as HTMLButtonElement,
         prepareCancelBtn: document.getElementById('prepareCancelBtn') as HTMLButtonElement,
+        previewBtn:       document.getElementById('previewPathBtn')   as HTMLButtonElement,
+        previewCloseBtn:  document.getElementById('previewCloseBtn')  as HTMLButtonElement,
         executeBtn:       document.getElementById('executeBtn')       as HTMLButtonElement,
         clearBtn:         document.getElementById('clearBtn')         as HTMLButtonElement,
 
@@ -152,6 +164,7 @@ export function createUIRegistry(): UIRegistry {
 
         // Visual Markers
         robotMarker: document.getElementById('robot-marker') as HTMLElement,
+        previewMarker: document.getElementById('previewMarker') as HTMLElement,
 
         // Shape Drawing Tools
         penBtn:          document.getElementById('penBtn')          as HTMLButtonElement,
@@ -164,7 +177,8 @@ export function createUIRegistry(): UIRegistry {
         clearMarkersBtn: document.getElementById('clearMarkersBtn') as HTMLButtonElement,
 
         // Raster / Fill Settings
-        fillAccordionToggle: document.getElementById('fillAccordionToggle') as HTMLButtonElement,
+        fillOffBtn: document.getElementById('fillOff') as HTMLButtonElement,
+        fillOnBtn:  document.getElementById('fillOn')  as HTMLButtonElement,
         fillSettingsPanel:   document.getElementById('fillSettingsPanel')   as HTMLElement,
         rasterBtnA:          document.getElementById('rasterA')            as HTMLButtonElement,
         rasterBtnB:          document.getElementById('rasterB')            as HTMLButtonElement,

--- a/frontend/src/core/UIRegistry.ts
+++ b/frontend/src/core/UIRegistry.ts
@@ -33,13 +33,8 @@ export interface UIRegistry {
     // Popup buttons
     prepareCloseBtn: HTMLButtonElement;
     prepareCancelBtn: HTMLButtonElement;
-    
-    // NEW: The button inside the popup that runs the simulation
     previewBtn: HTMLButtonElement; 
-    
-    // The button inside the popup that fires the laser
     executeBtn: HTMLButtonElement;
-    
     previewCloseBtn: HTMLButtonElement;
     clearBtn: HTMLButtonElement;
 
@@ -141,8 +136,6 @@ export function createUIRegistry(): UIRegistry {
         prepareBtn:       document.getElementById('prepareBtn')       as HTMLButtonElement,
         prepareCloseBtn:  document.getElementById('prepareCloseBtn')  as HTMLButtonElement,
         prepareCancelBtn: document.getElementById('prepareCancelBtn') as HTMLButtonElement,
-        
-        // Use 'previewBtn' for the simulation button as requested
         previewBtn:       document.getElementById('previewBtn')       as HTMLButtonElement, 
         executeBtn:       document.getElementById('executeBtn')       as HTMLButtonElement,
         

--- a/frontend/src/core/UIRegistry.ts
+++ b/frontend/src/core/UIRegistry.ts
@@ -22,6 +22,7 @@ export interface UIRegistry {
     previewPopup: HTMLElement;
     previewTimeDisplay: HTMLElement;
     previewCanvas: HTMLCanvasElement;
+    previewVideo: HTMLVideoElement;
 
     // --- Action Buttons ---
     settingsBtn: HTMLButtonElement;
@@ -127,6 +128,7 @@ export function createUIRegistry(): UIRegistry {
         previewPopup: document.getElementById('previewPopup') as HTMLElement,
         previewCanvas: document.getElementById('previewCanvas') as HTMLCanvasElement,
         previewTimeDisplay: document.getElementById('previewTimeDisplay') as HTMLElement,
+        previewVideo: document.getElementById('previewVideo') as HTMLVideoElement,
 
         // Action Buttons
         settingsBtn:      document.getElementById('settingsBtn')      as HTMLButtonElement,

--- a/frontend/src/core/UIRegistry.ts
+++ b/frontend/src/core/UIRegistry.ts
@@ -102,6 +102,7 @@ export interface UIRegistry {
     maxHeatDisplay: HTMLElement;
     heatAreaBtn: HTMLButtonElement;
     resetHeatAreaBtn: HTMLButtonElement;
+    heatLegend: HTMLElement;
 
     // --- Main Mode Switchers ---
     modeButtons: NodeListOf<HTMLElement>;
@@ -203,6 +204,7 @@ export function createUIRegistry(): UIRegistry {
         maxHeatDisplay: document.getElementById('max-heat-display') as HTMLElement,
         heatAreaBtn: document.getElementById('heatAreaBtn') as HTMLButtonElement,
         resetHeatAreaBtn: document.getElementById('resetHeatAreaBtn') as HTMLButtonElement,
+        heatLegend: document.getElementById('thermal-gradient-legend') as HTMLElement,
 
         // Main Mode Switchers
         modeButtons: document.querySelectorAll('.mode-btn'),

--- a/frontend/src/core/UIRegistry.ts
+++ b/frontend/src/core/UIRegistry.ts
@@ -5,7 +5,6 @@
  *
  * Centralized cache of all DOM elements used by the application.
  * Queried once at construction time to avoid repeated getElementById calls.
- * Every other module receives a reference to this single object.
  */
 
 export interface UIRegistry {
@@ -27,12 +26,21 @@ export interface UIRegistry {
     // --- Action Buttons ---
     settingsBtn: HTMLButtonElement;
     settingsCloseBtn: HTMLButtonElement;
+    
+    // Top panel button that opens the popup
     prepareBtn: HTMLButtonElement;
+    
+    // Popup buttons
     prepareCloseBtn: HTMLButtonElement;
     prepareCancelBtn: HTMLButtonElement;
-    previewBtn: HTMLButtonElement;
-    previewCloseBtn: HTMLButtonElement;
+    
+    // NEW: The button inside the popup that runs the simulation
+    previewBtn: HTMLButtonElement; 
+    
+    // The button inside the popup that fires the laser
     executeBtn: HTMLButtonElement;
+    
+    previewCloseBtn: HTMLButtonElement;
     clearBtn: HTMLButtonElement;
 
     // --- Hardware Controls (Robot / Laser) ---
@@ -109,10 +117,6 @@ export interface UIRegistry {
     heightDisplay: HTMLElement;
 }
 
-/**
- * Queries the DOM once and returns a frozen UIRegistry.
- * Call this after the DOM is ready (e.g. inside a 'load' listener).
- */
 export function createUIRegistry(): UIRegistry {
     return {
         // Core Viewport
@@ -133,12 +137,16 @@ export function createUIRegistry(): UIRegistry {
         // Action Buttons
         settingsBtn:      document.getElementById('settingsBtn')      as HTMLButtonElement,
         settingsCloseBtn: document.getElementById('settingsCloseBtn') as HTMLButtonElement,
+        
         prepareBtn:       document.getElementById('prepareBtn')       as HTMLButtonElement,
         prepareCloseBtn:  document.getElementById('prepareCloseBtn')  as HTMLButtonElement,
         prepareCancelBtn: document.getElementById('prepareCancelBtn') as HTMLButtonElement,
-        previewBtn:       document.getElementById('previewPathBtn')   as HTMLButtonElement,
-        previewCloseBtn:  document.getElementById('previewCloseBtn')  as HTMLButtonElement,
+        
+        // Use 'previewBtn' for the simulation button as requested
+        previewBtn:       document.getElementById('previewBtn')       as HTMLButtonElement, 
         executeBtn:       document.getElementById('executeBtn')       as HTMLButtonElement,
+        
+        previewCloseBtn:  document.getElementById('previewCloseBtn')  as HTMLButtonElement,
         clearBtn:         document.getElementById('clearBtn')         as HTMLButtonElement,
 
         // Hardware Controls

--- a/frontend/src/features/drawing/ExecutionManager.ts
+++ b/frontend/src/features/drawing/ExecutionManager.ts
@@ -1,54 +1,57 @@
-//frontend/src/features/drawing/ExecutionManager.ts
+//frontend/src/core/ExecutionManager.ts
 
-import { UIRegistry }    from '../../core/UIRegistry';
-import { AppState }      from '../../core/AppState';
+import { UIRegistry } from '../../core/UIRegistry';
+import { AppState } from '../../core/AppState';
 import { CanvasManager } from '../../ui/CanvasManager';
 
 /**
  * ExecutionManager
  *
- * Owns the lifecycle that begins once the user has finished drawing a shape:
- *   1. onShapeComplete  – records that a shape now exists (triggers button-state update)
- *   2. executePath      – reads speed / fill settings, sends path to backend, cleans up
- *   3. clearDrawing     – removes the shape and re-arms the selected tool
+ * Owns the lifecycle:
+ * 1. onShapeComplete  – records that a shape now exists
+ * 2. previewPath      – sends data, opens preview window
+ * 3. executePath      – sends execute command only (requires preview first)
+ * 4. clearDrawing     – resets everything
  */
 export class ExecutionManager {
-    constructor(
-        private readonly ui:                  UIRegistry,
-        private readonly state:               AppState,
-        private getCanvasManager:             () => CanvasManager | null,
-        private updateDrawButtonState:        () => void,
-    ) {}
+    private isPathPrepared: boolean = false;
 
-    // ---------------------------------------------------------------
-    // Shape-complete callback  (wired into CanvasManager construction)
-    // ---------------------------------------------------------------
+    constructor(
+        private readonly ui: UIRegistry,
+        private readonly state: AppState,
+        private getCanvasManager: () => CanvasManager | null,
+        private updateDrawButtonState: () => void,
+        private openPreviewWindow: () => void,
+    ) { 
+        this.updateExecuteButtonState();
+    }
 
     /**
-     * Called by CanvasManager the moment the user lifts the pointer after
-     * drawing a shape.  Records the type so that button-state logic knows
-     * a shape exists.
+     * Called by CanvasManager when the user finishes drawing a shape.
      */
     onShapeComplete(): void {
         if (this.state.selectedShape && this.state.selectedShape !== 'marker') {
             this.state.drawnShapeType = this.state.selectedShape;
+
+            // New shape drawn -> Invalidate previous path
+            this.isPathPrepared = false;
+
+            this.updateExecuteButtonState();
             this.updateDrawButtonState();
         }
     }
 
-    // ---------------------------------------------------------------
-    // Execute
-    // ---------------------------------------------------------------
-
     /**
-     * Validates inputs, sends the path to the backend via CanvasManager,
-     * and cleans up UI state on success.
+     * "Simulate" Action:
+     * 1. Sends path data to backend.
+     * 2. Opens the preview window to show the animation.
+     * 3. Enables the Execute button upon success.
      */
-    async executePath(): Promise<void> {
+    async previewPath(): Promise<void> {
         const cm = this.getCanvasManager();
         if (!cm) return;
 
-        const speed   = parseFloat(this.ui.speedInput.value);
+        const speed = parseFloat(this.ui.speedInput.value);
         const density = this.state.fillEnabled
             ? parseFloat(this.ui.rasterDensityInput.value)
             : 0;
@@ -58,56 +61,117 @@ export class ExecutionManager {
             return;
         }
 
+        // Disable controls while calculating
+        this.ui.previewBtn.disabled = true;
         this.ui.executeBtn.disabled = true;
-        this.ui.prepareBtn.disabled = true;
 
         try {
-            await cm.executePath(
+            // Send all data to backend via preview endpoint
+            await cm.previewPath(
                 speed,
                 String(this.state.selectedRasterPattern),
                 density,
                 this.state.fillEnabled,
             );
 
-            // Success – clean up
+            // Success: Path is now safe to execute
+            this.isPathPrepared = true;
+            this.updateExecuteButtonState();
+
+            this.ui.previewBtn.disabled = false;
+
+            // Open the preview window to show the path animation
+            this.openPreviewWindow();
+
+        } catch (e) {
+            console.error(e);
+            this.ui.previewBtn.disabled = false;
+            this.isPathPrepared = false;
+            this.updateExecuteButtonState();
+        }
+    }
+
+    /**
+     * "Execute" Action:
+     * Sends execute command to start the prepared path.
+     * Only works if path has been previewed first (Safety Interlock).
+     */
+    async executePath(): Promise<void> {
+        const cm = this.getCanvasManager();
+        if (!cm) return;
+
+        if (!this.isPathPrepared) {
+            alert('Please simulate the path first');
+            return;
+        }
+
+        this.ui.executeBtn.disabled = true;
+        this.ui.previewBtn.disabled = true;
+
+        try {
+            await cm.executeCommand();
+
             cm.clearDrawing();
             this.state.drawnShapeType = null;
+            this.isPathPrepared = false;
+            this.updateExecuteButtonState();
+
+            //Re-enable UI
             this.ui.toggleButtons.forEach(btn => btn.disabled = false);
             this.updateDrawButtonState();
 
-            // Re-arm the drawing tool that was active before execution
+            //Explicitly re-enable the simulate button so it can be used again
+            this.ui.previewBtn.disabled = false;
+
+            //Close the Prepare and Preview popups
+            this.ui.preparePopup.classList.remove('active');
+            this.ui.previewCloseBtn.click();
+
+            // 4. Re-arm the tool
             if (this.state.selectedShape && this.state.selectedShape !== 'marker') {
                 cm.setShapeType(this.state.selectedShape);
                 cm.enableDrawing();
             }
 
-            this.ui.preparePopup.classList.remove('active');
         } catch (e) {
             console.error(e);
             this.ui.executeBtn.disabled = false;
-            this.ui.prepareBtn.disabled = false;
+            this.ui.previewBtn.disabled = false;
         }
     }
 
-    // ---------------------------------------------------------------
-    // Clear
-    // ---------------------------------------------------------------
-
     /**
-     * Removes the current shape from the canvas and immediately re-arms
-     * the selected tool so the user can draw again without extra clicks.
+     * Removes the current shape from the canvas and resets state.
      */
     clearDrawing(): void {
         const cm = this.getCanvasManager();
 
         cm?.clearDrawing();
         this.state.drawnShapeType = null;
+        this.isPathPrepared = false;
+
+        this.updateExecuteButtonState();
         this.updateDrawButtonState();
 
         // Re-arm drawing if a shape tool is still selected
         if (cm && this.state.selectedShape && this.state.selectedShape !== 'marker') {
             cm.setShapeType(this.state.selectedShape);
             cm.enableDrawing();
+        }
+    }
+
+    /**
+     * Updates the execute button visual state based on preparation.
+     */
+    private updateExecuteButtonState(): void {
+        if (this.isPathPrepared) {
+            this.ui.executeBtn.disabled = false;
+            this.ui.executeBtn.style.pointerEvents = 'auto'; // Ensure clickable
+            this.ui.executeBtn.style.opacity = '1';
+        } else {
+            this.ui.executeBtn.disabled = true;
+            this.ui.executeBtn.style.pointerEvents = 'none'; // Ensure NOT clickable
+            this.ui.executeBtn.style.opacity = '0.3';
         }
     }
 }

--- a/frontend/src/features/drawing/ExecutionManager.ts
+++ b/frontend/src/features/drawing/ExecutionManager.ts
@@ -1,28 +1,24 @@
-//frontend/src/core/ExecutionManager.ts
-
 import { UIRegistry } from '../../core/UIRegistry';
 import { AppState } from '../../core/AppState';
 import { CanvasManager } from '../../ui/CanvasManager';
+import { PreviewManager } from '../drawing/PreviewManager';
 
 /**
  * ExecutionManager
  *
  * Owns the lifecycle:
- * 1. onShapeComplete  – records that a shape now exists
- * 2. previewPath      – sends data, opens preview window
- * 3. executePath      – sends execute command only (requires preview first)
- * 4. clearDrawing     – resets everything
+ * 1. onShapeComplete – records that a shape now exists
+ * 2. executePath     – sends execute command (requires preview first)
+ * 3. clearDrawing    – resets everything
  */
 export class ExecutionManager {
-    private isPathPrepared: boolean = false;
-
     constructor(
         private readonly ui: UIRegistry,
         private readonly state: AppState,
         private getCanvasManager: () => CanvasManager | null,
         private updateDrawButtonState: () => void,
-        private openPreviewWindow: () => void,
-    ) { 
+        private getPreviewManager: () => PreviewManager,
+    ) {
         this.updateExecuteButtonState();
     }
 
@@ -33,67 +29,21 @@ export class ExecutionManager {
         if (this.state.selectedShape && this.state.selectedShape !== 'marker') {
             this.state.drawnShapeType = this.state.selectedShape;
 
-            // New shape drawn -> Invalidate previous path
-            this.isPathPrepared = false;
-            this.ui.previewBtn.disabled = false;
+            // New shape drawn -> Invalidate preview state
+            const previewMgr = this.getPreviewManager();
+            previewMgr.resetPreviewState();
 
             this.updateExecuteButtonState();
             this.updateDrawButtonState();
         }
     }
 
-    /**
-     * "Simulate" Action:
-     * 1. Sends path data to backend.
-     * 2. Opens the preview window to show the animation.
-     * 3. Enables the Execute button upon success.
-     */
     async previewPath(): Promise<void> {
-        const cm = this.getCanvasManager();
-        if (!cm) return;
-
-        const speed = parseFloat(this.ui.speedInput.value);
-        const density = this.state.fillEnabled
-            ? parseFloat(this.ui.rasterDensityInput.value)
-            : 0;
-
-        if (isNaN(speed) || speed <= 0) {
-            alert('Invalid speed');
-            return;
-        }
-
-        // Disable controls while calculating
-        this.ui.previewBtn.disabled = true;
-        this.ui.executeBtn.disabled = true;
-
-        try {
-            // Send all data to backend via preview endpoint
-            await cm.previewPath(
-                speed,
-                String(this.state.selectedRasterPattern),
-                density,
-                this.state.fillEnabled,
-            );
-
-            // Success: Path is now safe to execute
-            this.isPathPrepared = true;
-            this.updateExecuteButtonState();
-
-            this.ui.previewBtn.disabled = false;
-
-            // Open the preview window to show the path animation
-            this.openPreviewWindow();
-
-        } catch (e) {
-            console.error(e);
-            this.ui.previewBtn.disabled = false;
-            this.isPathPrepared = false;
-            this.updateExecuteButtonState();
-        }
+        const previewMgr = this.getPreviewManager();
+        previewMgr.togglePreview(true);
     }
 
     /**
-     * "Execute" Action:
      * Sends execute command to start the prepared path.
      * Only works if path has been previewed first (Safety Interlock).
      */
@@ -101,77 +51,69 @@ export class ExecutionManager {
         const cm = this.getCanvasManager();
         if (!cm) return;
 
-        if (!this.isPathPrepared) {
-            alert('Please simulate the path first');
+        const previewMgr = this.getPreviewManager();
+        if (!previewMgr.hasPreviewedCurrent()) {
+            alert('Please preview the path first');
             return;
         }
 
         this.ui.executeBtn.disabled = true;
-        this.ui.previewBtn.disabled = true;
 
         try {
             await cm.executeCommand();
-
             cm.clearDrawing();
             this.state.drawnShapeType = null;
-            this.isPathPrepared = false;
-            this.updateExecuteButtonState();
 
-            //Re-enable UI
+            // Reset preview state on execution
+            previewMgr.resetPreviewState();
+
+            this.updateExecuteButtonState();
             this.ui.toggleButtons.forEach(btn => btn.disabled = false);
             this.updateDrawButtonState();
 
-            //Explicitly re-enable the simulate button so it can be used again
-            this.ui.previewBtn.disabled = false;
-
-            //Close the Prepare and Preview popups
+            // Close prepare popup
             this.ui.preparePopup.classList.remove('active');
-            this.ui.previewCloseBtn.click();
 
-            // 4. Re-arm the tool
+            // Re-arm the tool
             if (this.state.selectedShape && this.state.selectedShape !== 'marker') {
                 cm.setShapeType(this.state.selectedShape);
                 cm.enableDrawing();
             }
-
         } catch (e) {
             console.error(e);
             this.ui.executeBtn.disabled = false;
-            this.ui.previewBtn.disabled = false;
         }
     }
 
-    /**
-     * Removes the current shape from the canvas and resets state.
-     */
     clearDrawing(): void {
         const cm = this.getCanvasManager();
-
         cm?.clearDrawing();
         this.state.drawnShapeType = null;
-        this.isPathPrepared = false;
+
+        // Reset preview state on clear
+        const previewMgr = this.getPreviewManager();
+        previewMgr.resetPreviewState();
 
         this.updateExecuteButtonState();
         this.updateDrawButtonState();
 
-        // Re-arm drawing if a shape tool is still selected
         if (cm && this.state.selectedShape && this.state.selectedShape !== 'marker') {
             cm.setShapeType(this.state.selectedShape);
             cm.enableDrawing();
         }
     }
 
-    /**
-     * Updates the execute button visual state based on preparation.
-     */
     private updateExecuteButtonState(): void {
-        if (this.isPathPrepared) {
+        const previewMgr = this.getPreviewManager();
+        const hasPreview = previewMgr.hasPreviewedCurrent();
+
+        if (hasPreview) {
             this.ui.executeBtn.disabled = false;
-            this.ui.executeBtn.style.pointerEvents = 'auto'; // Ensure clickable
+            this.ui.executeBtn.style.pointerEvents = 'auto';
             this.ui.executeBtn.style.opacity = '1';
         } else {
             this.ui.executeBtn.disabled = true;
-            this.ui.executeBtn.style.pointerEvents = 'none'; // Ensure NOT clickable
+            this.ui.executeBtn.style.pointerEvents = 'none';
             this.ui.executeBtn.style.opacity = '0.3';
         }
     }

--- a/frontend/src/features/drawing/ExecutionManager.ts
+++ b/frontend/src/features/drawing/ExecutionManager.ts
@@ -35,6 +35,7 @@ export class ExecutionManager {
 
             // New shape drawn -> Invalidate previous path
             this.isPathPrepared = false;
+            this.ui.previewBtn.disabled = false;
 
             this.updateExecuteButtonState();
             this.updateDrawButtonState();

--- a/frontend/src/features/drawing/PreviewManager.ts
+++ b/frontend/src/features/drawing/PreviewManager.ts
@@ -147,17 +147,7 @@ export class PreviewManager {
       path.push({ x: previewData.x[i], y: previewData.y[i] });
     }
 
-    // Estimate duration
-    const speed = parseFloat(this.ui.speedInput.value) || 10;
-    let totalDistance = 0;
-    for (let i = 1; i < path.length; i++) {
-      const dx = path[i].x - path[i - 1].x;
-      const dy = path[i].y - path[i - 1].y;
-      totalDistance += Math.sqrt(dx * dx + dy * dy);
-    }
-    const duration = serverDuration || 10.0;;
-
-    this.handlePathData(path, duration);
+    this.handlePathData(path, serverDuration || 10);
   }
 
   private handlePathData(videoPath: Position[], duration: number): void {
@@ -166,12 +156,12 @@ export class PreviewManager {
       return;
     }
 
-    // 1. STORE SOURCE OF TRUTH (Video Coordinates)
+    //STORE SOURCE OF TRUTH (Video Coordinates)
     this.sourcePath = videoPath;
     this.durationSeconds = duration;
     this.hasPreviewedCurrentDrawing = true;
 
-    // 2. CALCULATE SCREEN COORDINATES
+    //CALCULATE SCREEN COORDINATES
     this.updatePathTransform();
 
     this.ui.previewDuration.textContent = `${duration.toFixed(1)}s`;

--- a/frontend/src/features/drawing/PreviewManager.ts
+++ b/frontend/src/features/drawing/PreviewManager.ts
@@ -122,7 +122,7 @@ export class PreviewManager {
     }
   }
 
-  public handlePathFromWebSocket(previewData: { x: number[], y: number[] }): void {
+  public handlePathFromWebSocket(previewData: { x: number[], y: number[] }, serverDuration?: number): void {
     if (!this.isPreviewActive) return;
 
     const path: Position[] = [];
@@ -139,7 +139,7 @@ export class PreviewManager {
       const dy = path[i].y - path[i - 1].y;
       totalDistance += Math.sqrt(dx * dx + dy * dy);
     }
-    const duration = totalDistance / (speed * 10 || 1);
+    const duration = serverDuration || 10.0;;
 
     this.handlePathData(path, duration);
   }

--- a/frontend/src/features/drawing/PreviewManager.ts
+++ b/frontend/src/features/drawing/PreviewManager.ts
@@ -86,8 +86,8 @@ export class PreviewManager {
             viewportW = viewportH * videoRatio;
         }
 
-        // 5. Apply dimensions to DOM
-        // The popup gets (viewport height + header height)
+        //Apply dimensions to DOM
+        //The popup gets (viewport height + header height)
         this.ui.previewPopup.style.left = `${targetLeft}px`;
         this.ui.previewPopup.style.top = `${prepareRect.top}px`;
         this.ui.previewPopup.style.width = `${viewportW}px`;
@@ -97,15 +97,6 @@ export class PreviewManager {
         //Matches the viewport exactly
         this.ui.previewCanvas.width = viewportW;
         this.ui.previewCanvas.height = viewportH;
-
-        //Update background snapshot
-        const dataUrl = cm.getVideoSnapshotDataURL();
-        const container = this.ui.previewCanvas.parentElement;
-        if (container) {
-            container.style.backgroundImage = `url(${dataUrl})`;
-            // Force stretch to match main viewport behavior
-            container.style.backgroundSize = '100% 100%'; 
-        }
 
         //Calculate Scale Factors
         //Now caleY maps video -> viewport (excluding header)

--- a/frontend/src/features/drawing/PreviewManager.ts
+++ b/frontend/src/features/drawing/PreviewManager.ts
@@ -10,11 +10,11 @@ export class PreviewManager {
     private durationSeconds: number = 0;
     private animationFrameId: number | null = null;
     
-    // Exact scaling factor (Video -> Preview)
+    //Exact scaling factor (Video -> Preview)
     private scaleX: number = 1;
     private scaleY: number = 1;
 
-    // Store marker size to perform manual centering in the loop
+    //Store marker size to perform manual centering in the loop
     private markerSize: number = 24;
 
     constructor(
@@ -22,7 +22,7 @@ export class PreviewManager {
         private readonly state: AppState,
         private getCanvasManager: () => CanvasManager | null,
     ) {
-        // Force border-box and remove CSS transform to give JS full control
+        //Force border-box and remove CSS transform to give JS full control
         this.ui.previewMarker.style.boxSizing = 'border-box';
         this.ui.previewMarker.style.transform = 'none';
         this.ui.previewMarker.style.margin = '0';
@@ -32,11 +32,11 @@ export class PreviewManager {
         const cm = this.getCanvasManager();
         if (!cm) return;
 
-        // 1. Activate UI elements FIRST so they have dimensions in the DOM
+        //Activate UI elements FIRST so they have dimensions in the DOM
         this.ui.overlay.classList.add('active'); 
         this.ui.previewPopup.classList.add('active');
 
-        // 2. Set the video source for the background immediately
+        //Set the video source for the background immediately
         if (this.ui.video.srcObject) {
             this.ui.previewVideo.srcObject = this.ui.video.srcObject;
             this.ui.previewVideo.muted = true;
@@ -48,26 +48,22 @@ export class PreviewManager {
             }
         }
 
-        // 3. Perform layout calculation NOW that elements are visible
+        //Perform layout calculation NOW that elements are visible
         this.updateLayout();
 
-        // 4. Update status and disable button while fetching
+        //Update status and disable button while fetching
         this.ui.previewTimeDisplay.textContent = "Requesting...";
         this.ui.previewBtn.disabled = true;
 
-        // 5. Fetch data and start
+        //Fetch data and start
         await this.updatePreviewData();
-        
-        // Note: We do NOT re-enable the button here immediately if we are waiting for WebSocket
-        // The button enabling happens in startAnimation or handlePathFromWebSocket
     }
 
-    // ... (closePreview and updateLayout methods remain the same) ...
     public closePreview(): void {
         this.ui.previewPopup.classList.remove('active');
         this.ui.overlay.classList.remove('active'); 
         
-        // Stop the video stream to save resources
+        //Stop the video stream to save resources
         this.ui.previewVideo.srcObject = null;
         
         this.stopAnimation();
@@ -78,55 +74,55 @@ export class PreviewManager {
         const videoH = this.ui.video.videoHeight || 1;
         const videoRatio = videoW / videoH;
 
-        // Measure actual header height from DOM
+        //Measure actual header height from DOM
         const header = this.ui.previewPopup.querySelector('.preview-header');
         const headerHeight = header ? header.getBoundingClientRect().height : 60;
 
-        // Calculate positioning based on prepare popup
+        //Calculate positioning based on prepare popup
         const prepareRect = this.ui.preparePopup.getBoundingClientRect();
         const sidebarWidth = 65.5; 
         const rightGap = window.innerWidth - prepareRect.right;
         const targetLeft = sidebarWidth + rightGap;
 
-        // Calculate available width for viewport content
+        //Calculate available width for viewport content
         const availableWidth = prepareRect.left - targetLeft - rightGap;
         
-        // Start with maximum width, calculate height maintaining aspect ratio
+        //Start with maximum width, calculate height maintaining aspect ratio
         let viewportW = availableWidth;
         let viewportH = viewportW / videoRatio;
 
-        // Check vertical bounds (must fit in window with header)
+        //Check vertical bounds (must fit in window with header)
         const maxViewportHeight = window.innerHeight - (rightGap * 2) - headerHeight;
         
         if (viewportH > maxViewportHeight) {
-            // Height-constrained: recalculate width from max height
+            //Height-constrained: recalculate width from max height
             viewportH = maxViewportHeight;
             viewportW = viewportH * videoRatio;
         }
 
-        // Round to integers for pixel-perfect alignment
+        //Round to integers for pixel-perfect alignment
         viewportW = Math.floor(viewportW);
         viewportH = Math.floor(viewportH);
 
-        // Apply dimensions to popup (viewport + header)
+        //Apply dimensions to popup (viewport + header)
         this.ui.previewPopup.style.left = `${targetLeft}px`;
         this.ui.previewPopup.style.top = `${prepareRect.top}px`;
         this.ui.previewPopup.style.width = `${viewportW}px`;
         this.ui.previewPopup.style.height = `${viewportH + headerHeight}px`;
 
-        // Set canvas internal resolution to match viewport exactly
+        //Set canvas internal resolution to match viewport exactly
         this.ui.previewCanvas.width = viewportW;
         this.ui.previewCanvas.height = viewportH;
 
-        // Calculate scale factors for coordinate transformation
+        //Calculate scale factors for coordinate transformation
         this.scaleX = viewportW / videoW;
         this.scaleY = viewportH / videoH;
 
-        // Update marker size with even integer snapping
+        //Update marker size with even integer snapping
         const baseMarkerSize = 24; 
         let scaledSize = Math.max(8, baseMarkerSize * (viewportW / 1920));
         
-        // Force even number to prevent sub-pixel centering issues
+        //Force even number to prevent sub-pixel centering issues
         scaledSize = Math.round(scaledSize);
         if (scaledSize % 2 !== 0) scaledSize += 1;
 
@@ -141,7 +137,7 @@ export class PreviewManager {
 
         this.stopAnimation();
 
-        // Ensure layout is valid before processing
+        //Ensure layout is valid before processing
         if (this.ui.previewPopup.classList.contains('active')) {
             this.updateLayout();
         }
@@ -152,8 +148,8 @@ export class PreviewManager {
         const isFill = this.state.fillEnabled;
 
         try {
-            // Send request to backend
-            // In REAL mode, this returns an empty path. In FAKE mode, it returns the path.
+            //Send request to backend
+            //In REAL mode, this returns an empty path. In FAKE mode, it returns the path.
             const response = await cm.previewPath(speed, rasterType, density, isFill);
             
             if (response.path && response.path.length > 0) {
@@ -200,7 +196,6 @@ export class PreviewManager {
         this.pathData = path;
         
         // Estimate duration based on simple distance calc (since robot didn't send duration)
-        // Or you could add 'duration' to the WS message as well.
         const speed = parseFloat(this.ui.speedInput.value) || 10;
         let totalDistance = 0;
         for (let i = 1; i < path.length; i++) {
@@ -221,7 +216,6 @@ export class PreviewManager {
         this.startAnimation();
     }
 
-    // ... (drawPathOverlay, startAnimation, stopAnimation, loop remain the same) ...
     private drawPathOverlay(): void {
         const ctx = this.ui.previewCanvas.getContext('2d');
         if (!ctx) return; 

--- a/frontend/src/features/drawing/PreviewManager.ts
+++ b/frontend/src/features/drawing/PreviewManager.ts
@@ -317,18 +317,13 @@ export class PreviewManager {
       Math.floor(progress * totalPoints),
       totalPoints - 1
     );
+
+    // Grab the current point (already in correct local viewport coordinates)
     const point = this.pathData[index];
 
-    // Convert canvas coordinates to DOM viewport coordinates
-    const canvasRect = this.ui.previewOverlay.getBoundingClientRect();
-    const scaleX = canvasRect.width / this.ui.previewOverlay.width;
-    const scaleY = canvasRect.height / this.ui.previewOverlay.height;
-
-    const domX = point.x * scaleX;
-    const domY = point.y * scaleY;
-
-    this.ui.previewMarker.style.left = `${domX}px`;
-    this.ui.previewMarker.style.top = `${domY}px`;
+    // Apply directly. The browser's #app-scaler will handle the zoom automatically!
+    this.ui.previewMarker.style.left = `${point.x}px`;
+    this.ui.previewMarker.style.top = `${point.y}px`;
 
     this.animationFrameId = requestAnimationFrame(() => this.animationLoop());
   }

--- a/frontend/src/features/drawing/PreviewManager.ts
+++ b/frontend/src/features/drawing/PreviewManager.ts
@@ -24,16 +24,16 @@ export class PreviewManager {
         const cm = this.getCanvasManager();
         if (!cm) return;
 
-        // 1. Activate UI elements
+        //Activate UI elements
         this.ui.overlay.classList.add('active'); 
         this.ui.previewPopup.classList.add('active');
         this.ui.previewBtn.disabled = true;
         this.ui.previewTimeDisplay.textContent = "Calculating...";
 
-        // 2. Perform Layout Calculation
+        //Perform layout calculation
         this.updateLayout(cm);
 
-        // 3. Fetch Data & Start
+        //Fetch data and start
         await this.updatePreviewData();
         this.ui.previewBtn.disabled = false;
     }
@@ -46,34 +46,33 @@ export class PreviewManager {
 
     /**
      * Resizes and positions the Preview Window.
-     * Enforces aspect ratio of the VIDEO (Robot Space).
-     * Calculates position based on the Prepare Menu's right-margin.
+     * Enforces aspect ratio of the video.
+     * Calculates position based on the prepare menu's right-margin.
      */
     private updateLayout(cm: CanvasManager): void {
         const videoW = this.ui.video.videoWidth || 1;
         const videoH = this.ui.video.videoHeight || 1;
         const videoRatio = videoW / videoH;
 
-        // 1. Measure Header Height (static offset)
-        // We need to query the header inside the popup to know how much extra space to reserve
+        //Measure header height
+        // e need to query the header inside the popup to know how much extra space to reserve
         const header = this.ui.previewPopup.querySelector('.preview-header');
         const headerHeight = header ? header.getBoundingClientRect().height : 60; // Fallback to 60 if hidden
 
-        // 2. Calculate Positioning (Same as before)
+        //Calculate positioning (Same as before)
         const prepareRect = this.ui.preparePopup.getBoundingClientRect();
         const sidebarWidth = 65.5; 
         const rightGap = window.innerWidth - prepareRect.right;
         const targetLeft = sidebarWidth + rightGap;
 
-        // 3. Calculate Available Width for the CONTENT (Canvas/Video)
-        // This is the width of the cyan box in your mind
+        //Calculate available width for the content (Canvas/video)
         const availableWidth = prepareRect.left - targetLeft - rightGap;
         
-        // 4. Calculate Target Dimensions for the VIEWPORT ONLY
+        //Calculate target dimensions for the viewport only
         let viewportW = availableWidth;
         let viewportH = viewportW / videoRatio;
 
-        // Check vertical bounds (Window Height - Margins - Header Height)
+        //Check vertical bounds (Window height - margins - header height)
         const maxViewportHeight = window.innerHeight - (rightGap * 2) - headerHeight;
         
         if (viewportH > maxViewportHeight) {
@@ -81,33 +80,33 @@ export class PreviewManager {
             viewportW = viewportH * videoRatio;
         }
 
-        // 5. Apply Dimensions to DOM
-        // The Popup gets (Viewport Height + Header Height)
+        // 5. Apply dimensions to DOM
+        // The popup gets (viewport height + header height)
         this.ui.previewPopup.style.left = `${targetLeft}px`;
         this.ui.previewPopup.style.top = `${prepareRect.top}px`;
         this.ui.previewPopup.style.width = `${viewportW}px`;
         this.ui.previewPopup.style.height = `${viewportH + headerHeight}px`;
 
-        // 6. Update Internal Canvas Resolution
-        // Matches the viewport exactly
+        //Update internal canvas resolution
+        //Matches the viewport exactly
         this.ui.previewCanvas.width = viewportW;
         this.ui.previewCanvas.height = viewportH;
 
-        // 7. Update Background Snapshot
+        //Update background snapshot
         const dataUrl = cm.getCanvasDataURL();
         const container = this.ui.previewCanvas.parentElement;
         if (container) {
             container.style.backgroundImage = `url(${dataUrl})`;
-            // Force stretch to match Main Viewport behavior
+            // Force stretch to match main viewport behavior
             container.style.backgroundSize = '100% 100%'; 
         }
 
-        // 8. Calculate Scale Factors
-        // Now ScaleY maps Video -> Viewport (excluding header), which is correct
+        //Calculate Scale Factors
+        //Now caleY maps video -> viewport (excluding header)
         this.scaleX = viewportW / videoW;
         this.scaleY = viewportH / videoH;
 
-        // 9. Update Marker Size
+        //Update marker size
         const baseMarkerSize = 24; 
         const scaledSize = Math.max(8, baseMarkerSize * (viewportW / 1920)); 
         this.ui.previewMarker.style.width = `${scaledSize}px`;
@@ -151,7 +150,7 @@ export class PreviewManager {
         ctx.clearRect(0, 0, this.ui.previewCanvas.width, this.ui.previewCanvas.height);
         
         ctx.beginPath();
-        // Cyan path matching the robot's intent
+        //Cyan path matching the robot's intent
         ctx.strokeStyle = '#00ffff'; 
         ctx.lineWidth = 2; 
         ctx.lineJoin = 'round';

--- a/frontend/src/features/drawing/PreviewManager.ts
+++ b/frontend/src/features/drawing/PreviewManager.ts
@@ -1,0 +1,207 @@
+import { UIRegistry } from '../../core/UIRegistry';
+import { AppState } from '../../core/AppState';
+import { CanvasManager } from '../../ui/CanvasManager';
+import { Position } from '../../ui/types';
+
+export class PreviewManager {
+    private isAnimating: boolean = false;
+    private startTime: number = 0;
+    private pathData: Position[] = [];
+    private durationSeconds: number = 0;
+    private animationFrameId: number | null = null;
+    
+    // Exact scaling factor (Video -> Preview)
+    private scaleX: number = 1;
+    private scaleY: number = 1;
+
+    constructor(
+        private readonly ui: UIRegistry,
+        private readonly state: AppState,
+        private getCanvasManager: () => CanvasManager | null,
+    ) {}
+
+    public async openPreview(): Promise<void> {
+        const cm = this.getCanvasManager();
+        if (!cm) return;
+
+        // 1. Activate UI elements
+        this.ui.overlay.classList.add('active'); 
+        this.ui.previewPopup.classList.add('active');
+        this.ui.previewBtn.disabled = true;
+        this.ui.previewTimeDisplay.textContent = "Calculating...";
+
+        // 2. Perform Layout Calculation
+        this.updateLayout(cm);
+
+        // 3. Fetch Data & Start
+        await this.updatePreviewData();
+        this.ui.previewBtn.disabled = false;
+    }
+
+    public closePreview(): void {
+        this.ui.previewPopup.classList.remove('active');
+        this.ui.overlay.classList.remove('active'); 
+        this.stopAnimation();
+    }
+
+    /**
+     * Resizes and positions the Preview Window.
+     * Enforces aspect ratio of the VIDEO (Robot Space).
+     * Calculates position based on the Prepare Menu's right-margin.
+     */
+    private updateLayout(cm: CanvasManager): void {
+        const videoW = this.ui.video.videoWidth || 1;
+        const videoH = this.ui.video.videoHeight || 1;
+        const videoRatio = videoW / videoH;
+
+        // 1. Measure Header Height (static offset)
+        // We need to query the header inside the popup to know how much extra space to reserve
+        const header = this.ui.previewPopup.querySelector('.preview-header');
+        const headerHeight = header ? header.getBoundingClientRect().height : 60; // Fallback to 60 if hidden
+
+        // 2. Calculate Positioning (Same as before)
+        const prepareRect = this.ui.preparePopup.getBoundingClientRect();
+        const sidebarWidth = 65.5; 
+        const rightGap = window.innerWidth - prepareRect.right;
+        const targetLeft = sidebarWidth + rightGap;
+
+        // 3. Calculate Available Width for the CONTENT (Canvas/Video)
+        // This is the width of the cyan box in your mind
+        const availableWidth = prepareRect.left - targetLeft - rightGap;
+        
+        // 4. Calculate Target Dimensions for the VIEWPORT ONLY
+        let viewportW = availableWidth;
+        let viewportH = viewportW / videoRatio;
+
+        // Check vertical bounds (Window Height - Margins - Header Height)
+        const maxViewportHeight = window.innerHeight - (rightGap * 2) - headerHeight;
+        
+        if (viewportH > maxViewportHeight) {
+            viewportH = maxViewportHeight;
+            viewportW = viewportH * videoRatio;
+        }
+
+        // 5. Apply Dimensions to DOM
+        // The Popup gets (Viewport Height + Header Height)
+        this.ui.previewPopup.style.left = `${targetLeft}px`;
+        this.ui.previewPopup.style.top = `${prepareRect.top}px`;
+        this.ui.previewPopup.style.width = `${viewportW}px`;
+        this.ui.previewPopup.style.height = `${viewportH + headerHeight}px`;
+
+        // 6. Update Internal Canvas Resolution
+        // Matches the viewport exactly
+        this.ui.previewCanvas.width = viewportW;
+        this.ui.previewCanvas.height = viewportH;
+
+        // 7. Update Background Snapshot
+        const dataUrl = cm.getCanvasDataURL();
+        const container = this.ui.previewCanvas.parentElement;
+        if (container) {
+            container.style.backgroundImage = `url(${dataUrl})`;
+            // Force stretch to match Main Viewport behavior
+            container.style.backgroundSize = '100% 100%'; 
+        }
+
+        // 8. Calculate Scale Factors
+        // Now ScaleY maps Video -> Viewport (excluding header), which is correct
+        this.scaleX = viewportW / videoW;
+        this.scaleY = viewportH / videoH;
+
+        // 9. Update Marker Size
+        const baseMarkerSize = 24; 
+        const scaledSize = Math.max(8, baseMarkerSize * (viewportW / 1920)); 
+        this.ui.previewMarker.style.width = `${scaledSize}px`;
+        this.ui.previewMarker.style.height = `${scaledSize}px`;
+    }
+
+    public async updatePreviewData(): Promise<void> {
+        const cm = this.getCanvasManager();
+        if (!cm) return;
+
+        this.stopAnimation();
+
+        if (this.ui.previewPopup.classList.contains('active')) {
+            this.updateLayout(cm);
+        }
+
+        const speed = parseFloat(this.ui.speedInput.value) || 10;
+        const density = this.state.fillEnabled ? parseFloat(this.ui.rasterDensityInput.value) : 10;
+        const rasterType = this.state.selectedRasterPattern || '';
+        const isFill = this.state.fillEnabled;
+
+        try {
+            const response = await cm.getPreviewPath(speed, rasterType, density, isFill);
+            
+            this.pathData = response.path;
+            this.durationSeconds = response.duration;
+            this.ui.previewTimeDisplay.textContent = `Est. Time: ${this.durationSeconds.toFixed(1)}s`;
+
+            this.drawPathOverlay(); 
+            this.startAnimation();
+        } catch (e) {
+            console.error(e);
+            this.ui.previewTimeDisplay.textContent = "Error";
+        }
+    }
+
+    private drawPathOverlay(): void {
+        const ctx = this.ui.previewCanvas.getContext('2d');
+        if (!ctx || this.pathData.length < 2) return;
+
+        ctx.clearRect(0, 0, this.ui.previewCanvas.width, this.ui.previewCanvas.height);
+        
+        ctx.beginPath();
+        // Cyan path matching the robot's intent
+        ctx.strokeStyle = '#00ffff'; 
+        ctx.lineWidth = 2; 
+        ctx.lineJoin = 'round';
+        ctx.lineCap = 'round';
+
+        const start = this.pathData[0];
+        ctx.moveTo(start.x * this.scaleX, start.y * this.scaleY);
+
+        for (let i = 1; i < this.pathData.length; i++) {
+            const p = this.pathData[i];
+            ctx.lineTo(p.x * this.scaleX, p.y * this.scaleY);
+        }
+        ctx.stroke();
+    }
+
+    private startAnimation(): void {
+        this.isAnimating = true;
+        this.startTime = performance.now();
+        this.ui.previewMarker.style.display = 'block';
+        this.loop();
+    }
+
+    private stopAnimation(): void {
+        this.isAnimating = false;
+        if (this.animationFrameId) cancelAnimationFrame(this.animationFrameId);
+        this.ui.previewMarker.style.display = 'none';
+    }
+
+    private loop(): void {
+        if (!this.isAnimating || this.pathData.length === 0) return;
+
+        const now = performance.now();
+        const elapsed = (now - this.startTime) / 1000; 
+
+        let progress = elapsed / this.durationSeconds;
+        if (progress >= 1) {
+            this.startTime = performance.now();
+            progress = 0;
+        }
+
+        const totalPoints = this.pathData.length;
+        const index = Math.min(Math.floor(progress * totalPoints), totalPoints - 1);
+        const point = this.pathData[index];
+
+        const domX = point.x * this.scaleX;
+        const domY = point.y * this.scaleY;
+
+        this.ui.previewMarker.style.left = `${domX}px`;
+        this.ui.previewMarker.style.top = `${domY}px`;
+
+        this.animationFrameId = requestAnimationFrame(() => this.loop());
+    }
+}

--- a/frontend/src/features/drawing/PreviewManager.ts
+++ b/frontend/src/features/drawing/PreviewManager.ts
@@ -61,12 +61,15 @@ export class PreviewManager {
 
     public closePreview(): void {
         this.ui.previewPopup.classList.remove('active');
-        this.ui.overlay.classList.remove('active'); 
+        this.ui.overlay.classList.remove('active');
         
         //Stop the video stream to save resources
         this.ui.previewVideo.srcObject = null;
         
         this.stopAnimation();
+
+        // Re-enable the simulate button so the user can try again
+        this.ui.previewBtn.disabled = false;
     }
 
     private updateLayout(): void {

--- a/frontend/src/features/drawing/PreviewManager.ts
+++ b/frontend/src/features/drawing/PreviewManager.ts
@@ -93,7 +93,7 @@ export class PreviewManager {
         this.ui.previewCanvas.height = viewportH;
 
         //Update background snapshot
-        const dataUrl = cm.getCanvasDataURL();
+        const dataUrl = cm.getVideoSnapshotDataURL();
         const container = this.ui.previewCanvas.parentElement;
         if (container) {
             container.style.backgroundImage = `url(${dataUrl})`;

--- a/frontend/src/features/drawing/PreviewManager.ts
+++ b/frontend/src/features/drawing/PreviewManager.ts
@@ -30,6 +30,11 @@ export class PreviewManager {
         this.ui.previewBtn.disabled = true;
         this.ui.previewTimeDisplay.textContent = "Calculating...";
 
+        if (this.ui.video.srcObject) {
+            this.ui.previewVideo.srcObject = this.ui.video.srcObject;
+            this.ui.previewVideo.play().catch(e => console.warn("Preview play error", e));
+        }
+
         //Perform layout calculation
         this.updateLayout(cm);
 
@@ -41,6 +46,7 @@ export class PreviewManager {
     public closePreview(): void {
         this.ui.previewPopup.classList.remove('active');
         this.ui.overlay.classList.remove('active'); 
+        this.ui.previewVideo.srcObject = null;
         this.stopAnimation();
     }
 

--- a/frontend/src/features/drawing/PreviewManager.ts
+++ b/frontend/src/features/drawing/PreviewManager.ts
@@ -1,3 +1,5 @@
+//frontend/src/features/drawing/PreviewManager.ts
+
 import { UIRegistry } from '../../core/UIRegistry';
 import { AppState } from '../../core/AppState';
 import { CanvasManager } from '../../ui/CanvasManager';

--- a/frontend/src/features/drawing/PreviewManager.ts
+++ b/frontend/src/features/drawing/PreviewManager.ts
@@ -10,11 +10,11 @@ export class PreviewManager {
     private durationSeconds: number = 0;
     private animationFrameId: number | null = null;
     
-    //Exact scaling factor (Video -> Preview)
+    // Exact scaling factor (Video -> Preview)
     private scaleX: number = 1;
     private scaleY: number = 1;
 
-    //Store marker size to perform manual centering in the loop
+    // Store marker size to perform manual centering in the loop
     private markerSize: number = 24;
 
     constructor(
@@ -22,7 +22,7 @@ export class PreviewManager {
         private readonly state: AppState,
         private getCanvasManager: () => CanvasManager | null,
     ) {
-        //Force border-box and remove CSS transform to give JS full control
+        // Force border-box and remove CSS transform to give JS full control
         this.ui.previewMarker.style.boxSizing = 'border-box';
         this.ui.previewMarker.style.transform = 'none';
         this.ui.previewMarker.style.margin = '0';
@@ -32,102 +32,105 @@ export class PreviewManager {
         const cm = this.getCanvasManager();
         if (!cm) return;
 
-        //Activate UI elements
+        // 1. Activate UI elements FIRST so they have dimensions in the DOM
         this.ui.overlay.classList.add('active'); 
         this.ui.previewPopup.classList.add('active');
-        this.ui.previewBtn.disabled = true;
-        this.ui.previewTimeDisplay.textContent = "Calculating...";
 
-        // Set the video source for the background
+        // 2. Set the video source for the background immediately
         if (this.ui.video.srcObject) {
             this.ui.previewVideo.srcObject = this.ui.video.srcObject;
-            this.ui.previewVideo.play().catch(e => console.warn("Preview play error", e));
+            this.ui.previewVideo.muted = true;
+            
+            try {
+                await this.ui.previewVideo.play();
+            } catch (e) {
+                console.warn("Preview video play error:", e);
+            }
         }
 
-        //Perform layout calculation
+        // 3. Perform layout calculation NOW that elements are visible
         this.updateLayout();
 
-        //Fetch data and start
+        // 4. Update status and disable button while fetching
+        this.ui.previewTimeDisplay.textContent = "Requesting...";
+        this.ui.previewBtn.disabled = true;
+
+        // 5. Fetch data and start
         await this.updatePreviewData();
-        this.ui.previewBtn.disabled = false;
+        
+        // Note: We do NOT re-enable the button here immediately if we are waiting for WebSocket
+        // The button enabling happens in startAnimation or handlePathFromWebSocket
     }
 
+    // ... (closePreview and updateLayout methods remain the same) ...
     public closePreview(): void {
         this.ui.previewPopup.classList.remove('active');
         this.ui.overlay.classList.remove('active'); 
+        
+        // Stop the video stream to save resources
         this.ui.previewVideo.srcObject = null;
+        
         this.stopAnimation();
     }
 
-    /**
-     * Resizes and positions the Preview Window.
-     * Enforces aspect ratio of the video.
-     * Calculates position based on the prepare menu's right-margin.
-     */
     private updateLayout(): void {
         const videoW = this.ui.video.videoWidth || 1;
         const videoH = this.ui.video.videoHeight || 1;
         const videoRatio = videoW / videoH;
 
-        //Measure header height
-        // e need to query the header inside the popup to know how much extra space to reserve
+        // Measure actual header height from DOM
         const header = this.ui.previewPopup.querySelector('.preview-header');
-        const headerHeight = header ? header.getBoundingClientRect().height : 60; // Fallback to 60 if hidden
+        const headerHeight = header ? header.getBoundingClientRect().height : 60;
 
-        //Calculate positioning (Same as before)
+        // Calculate positioning based on prepare popup
         const prepareRect = this.ui.preparePopup.getBoundingClientRect();
         const sidebarWidth = 65.5; 
         const rightGap = window.innerWidth - prepareRect.right;
         const targetLeft = sidebarWidth + rightGap;
 
-        //Calculate available width for the content (Canvas/video)
+        // Calculate available width for viewport content
         const availableWidth = prepareRect.left - targetLeft - rightGap;
         
-        //Calculate target dimensions for the viewport only
+        // Start with maximum width, calculate height maintaining aspect ratio
         let viewportW = availableWidth;
         let viewportH = viewportW / videoRatio;
 
-        //Check vertical bounds (Window height - margins - header height)
+        // Check vertical bounds (must fit in window with header)
         const maxViewportHeight = window.innerHeight - (rightGap * 2) - headerHeight;
         
         if (viewportH > maxViewportHeight) {
+            // Height-constrained: recalculate width from max height
             viewportH = maxViewportHeight;
             viewportW = viewportH * videoRatio;
         }
 
-        // Round to integers to ensure pixel-perfect canvas alignment
+        // Round to integers for pixel-perfect alignment
         viewportW = Math.floor(viewportW);
         viewportH = Math.floor(viewportH);
 
-        //Apply dimensions to DOM
-        //The popup gets (viewport height + header height)
+        // Apply dimensions to popup (viewport + header)
         this.ui.previewPopup.style.left = `${targetLeft}px`;
         this.ui.previewPopup.style.top = `${prepareRect.top}px`;
         this.ui.previewPopup.style.width = `${viewportW}px`;
         this.ui.previewPopup.style.height = `${viewportH + headerHeight}px`;
 
-        //Update internal canvas resolution
-        //Matches the viewport exactly
+        // Set canvas internal resolution to match viewport exactly
         this.ui.previewCanvas.width = viewportW;
         this.ui.previewCanvas.height = viewportH;
 
-        //Calculate Scale Factors
-        //Now caleY maps video -> viewport (excluding header)
+        // Calculate scale factors for coordinate transformation
         this.scaleX = viewportW / videoW;
         this.scaleY = viewportH / videoH;
 
-        //Update marker size
+        // Update marker size with even integer snapping
         const baseMarkerSize = 24; 
         let scaledSize = Math.max(8, baseMarkerSize * (viewportW / 1920));
         
-        //Snap size to an EVEN INTEGER. 
-        //An odd size (e.g. 13px) means the center is at 6.5px.
+        // Force even number to prevent sub-pixel centering issues
         scaledSize = Math.round(scaledSize);
         if (scaledSize % 2 !== 0) scaledSize += 1;
 
-        //Update local state so the loop knows the exact size
         this.markerSize = scaledSize;
-
         this.ui.previewMarker.style.width = `${this.markerSize}px`;
         this.ui.previewMarker.style.height = `${this.markerSize}px`;
     }
@@ -138,6 +141,7 @@ export class PreviewManager {
 
         this.stopAnimation();
 
+        // Ensure layout is valid before processing
         if (this.ui.previewPopup.classList.contains('active')) {
             this.updateLayout();
         }
@@ -148,47 +152,87 @@ export class PreviewManager {
         const isFill = this.state.fillEnabled;
 
         try {
-            //Get snapshot of the original drawing (Fabric canvas only)
-            const snapshotUrl = cm.getCanvasDataURL();
-            const snapshotImg = new Image();
+            // Send request to backend
+            // In REAL mode, this returns an empty path. In FAKE mode, it returns the path.
+            const response = await cm.previewPath(speed, rasterType, density, isFill);
             
-            //Load snapshot and fetch simulation path in parallel
-            const [_, response] = await Promise.all([
-                new Promise(resolve => {
-                    snapshotImg.onload = resolve;
-                    snapshotImg.src = snapshotUrl;
-                }),
-                cm.getPreviewPath(speed, rasterType, density, isFill)
-            ]);
-            
-            this.pathData = response.path;
-            this.durationSeconds = response.duration;
-            this.ui.previewTimeDisplay.textContent = `Est. Time: ${this.durationSeconds.toFixed(1)}s`;
+            if (response.path && response.path.length > 0) {
+                // --- FAKE MODE DETECTED (Data came back in HTTP response) ---
+                this.pathData = response.path;
+                this.durationSeconds = response.duration;
+                this.ui.previewTimeDisplay.textContent = `Est. Time: ${this.durationSeconds.toFixed(1)}s`;
+                this.ui.previewBtn.disabled = false;
+                
+                this.drawPathOverlay(); 
+                this.startAnimation();
+            } else {
+                // --- REAL MODE (No data in HTTP response) ---
+                // We must wait for the WebSocket to deliver 'path_preview'
+                this.ui.previewTimeDisplay.textContent = "Computing (Waiting for Robot)...";
+                // Keep button disabled until WS data arrives
+                this.ui.previewBtn.disabled = true;
+            }
 
-            //Draw Snapshot (Original) + Path (Overlay)
-            this.drawPathOverlay(snapshotImg); 
-            this.startAnimation();
         } catch (e) {
             console.error(e);
             this.ui.previewTimeDisplay.textContent = "Error";
+            this.ui.previewBtn.disabled = false;
         }
     }
 
-    private drawPathOverlay(backgroundImage?: HTMLImageElement): void {
+    /**
+     * Called by AppController when a 'path_preview' message arrives via WebSocket.
+     * format: { x: [1,2...], y: [3,4...] } (Structure of Arrays)
+     */
+    public handlePathFromWebSocket(previewData: { x: number[], y: number[] }): void {
+        if (!this.ui.previewPopup.classList.contains('active')) return;
+
+        // Convert SOA (Structure of Arrays) to AOS (Array of Objects)
+        const path: Position[] = [];
+        const len = Math.min(previewData.x.length, previewData.y.length);
+        
+        for (let i = 0; i < len; i++) {
+            path.push({ x: previewData.x[i], y: previewData.y[i] });
+        }
+
+        if (path.length === 0) return;
+
+        this.pathData = path;
+        
+        // Estimate duration based on simple distance calc (since robot didn't send duration)
+        // Or you could add 'duration' to the WS message as well.
+        const speed = parseFloat(this.ui.speedInput.value) || 10;
+        let totalDistance = 0;
+        for (let i = 1; i < path.length; i++) {
+            const dx = path[i].x - path[i-1].x;
+            const dy = path[i].y - path[i-1].y;
+            totalDistance += Math.sqrt(dx*dx + dy*dy);
+        }
+        
+        // Arbitrary scaling for duration display if speed is abstract
+        // If speed is mm/s and pixels are converted, this needs unit math. 
+        // For now, assuming pixels and 'speed' factor:
+        this.durationSeconds = totalDistance / (speed * 10 || 1); 
+
+        this.ui.previewTimeDisplay.textContent = `Ready`;
+        this.ui.previewBtn.disabled = false;
+
+        this.drawPathOverlay();
+        this.startAnimation();
+    }
+
+    // ... (drawPathOverlay, startAnimation, stopAnimation, loop remain the same) ...
+    private drawPathOverlay(): void {
         const ctx = this.ui.previewCanvas.getContext('2d');
         if (!ctx) return; 
 
+        // Clear canvas completely so the video element behind it shows through
         ctx.clearRect(0, 0, this.ui.previewCanvas.width, this.ui.previewCanvas.height);
         
-        // Draw original user drawing (Scaled to fit viewport)
-        if (backgroundImage) {
-            ctx.drawImage(backgroundImage, 0, 0, this.ui.previewCanvas.width, this.ui.previewCanvas.height);
-        }
-
         if (this.pathData.length < 2) return;
 
         ctx.beginPath();
-        //Cyan path matching the robot's intent
+        // Cyan path matching the robot's intent
         ctx.strokeStyle = '#00ffff'; 
         ctx.lineWidth = 2; 
         ctx.lineJoin = 'round';
@@ -223,7 +267,10 @@ export class PreviewManager {
         const now = performance.now();
         const elapsed = (now - this.startTime) / 1000; 
 
-        let progress = elapsed / this.durationSeconds;
+        // Avoid division by zero
+        const duration = this.durationSeconds > 0 ? this.durationSeconds : 1;
+
+        let progress = elapsed / duration;
         if (progress >= 1) {
             this.startTime = performance.now();
             progress = 0;
@@ -236,9 +283,7 @@ export class PreviewManager {
         const domX = point.x * this.scaleX;
         const domY = point.y * this.scaleY;
 
-        //Manual centering calculation
-        //top/left = center - (size / 2)
-        //This avoids CSS transform ambiguity and ensures integer alignment
+        // Manual centering calculation
         const offset = this.markerSize / 2;
         
         this.ui.previewMarker.style.left = `${domX - offset}px`;

--- a/frontend/src/features/drawing/PreviewManager.ts
+++ b/frontend/src/features/drawing/PreviewManager.ts
@@ -3,289 +3,337 @@ import { AppState } from '../../core/AppState';
 import { CanvasManager } from '../../ui/CanvasManager';
 import { Position } from '../../ui/types';
 
+/**
+ * PreviewManager - CAD-style toolpath overlay with animated follower
+ */
 export class PreviewManager {
-    private isAnimating: boolean = false;
-    private startTime: number = 0;
-    private pathData: Position[] = [];
-    private durationSeconds: number = 0;
-    private animationFrameId: number | null = null;
+  private ctx: CanvasRenderingContext2D;
+  private isPreviewActive: boolean = false;
+  private pathData: Position[] = [];
+  private durationSeconds: number = 0;
+  private hasPreviewedCurrentDrawing: boolean = false;
+  
+  // Animation state
+  private isAnimating: boolean = false;
+  private animationStartTime: number = 0;
+  private animationFrameId: number | null = null;
+  
+  // Visual styling
+  private readonly PATH_COLOR = '#ffff00'; // Neon Yellow
+  private readonly PATH_WIDTH = 4;
+  private readonly DASH_PATTERN = [12, 6];
+  private readonly GLOW_COLOR = 'rgba(255, 255, 0, 0.4)';
+  private readonly GLOW_WIDTH = 10;
+  
+  constructor(
+    private readonly ui: UIRegistry,
+    private readonly state: AppState,
+    private getCanvasManager: () => CanvasManager | null,
+  ) {
+    const ctx = this.ui.previewOverlay.getContext('2d');
+    if (!ctx) throw new Error('Preview overlay context not available');
+    this.ctx = ctx;
     
-    //Exact scaling factor (Video -> Preview)
-    private scaleX: number = 1;
-    private scaleY: number = 1;
+    this.updateOverlaySize();
+    
+    // Disable execute button immediately when clicked
+    const executeBtn = this.getExecuteBtn();
+    if (executeBtn) {
+      executeBtn.addEventListener('click', () => {
+        this.setExecuteButtonState(false);
+      });
+    }
+  }
 
-    //Store marker size to perform manual centering in the loop
-    private markerSize: number = 24;
+  private getExecuteBtn(): HTMLButtonElement | null {
+    return document.getElementById('executeBtn') as HTMLButtonElement | null;
+  }
 
-    constructor(
-        private readonly ui: UIRegistry,
-        private readonly state: AppState,
-        private getCanvasManager: () => CanvasManager | null,
-    ) {
-        //Force border-box and remove CSS transform to give JS full control
-        this.ui.previewMarker.style.boxSizing = 'border-box';
-        this.ui.previewMarker.style.transform = 'none';
-        this.ui.previewMarker.style.margin = '0';
+  /**
+   * Handle the complex state of the execute button (Disabled prop + CSS styles)
+   */
+  private setExecuteButtonState(isEnabled: boolean): void {
+    const btn = this.getExecuteBtn();
+    if (!btn) return;
+
+    if (isEnabled) {
+        btn.disabled = false;
+        // MUST override the inline styles set by ExecutionManager
+        btn.style.pointerEvents = 'auto';
+        btn.style.opacity = '1';
+    } else {
+        btn.disabled = true;
+        btn.style.pointerEvents = 'none';
+        btn.style.opacity = '0.3';
+    }
+  }
+
+  public togglePreview(enable: boolean): void {
+    this.isPreviewActive = enable;
+    
+    if (enable) {
+      this.ui.previewToggleOn.classList.add('active');
+      this.ui.previewToggleOff.classList.remove('active');
+      this.ui.previewInfoPanel.classList.add('open');
+      this.refreshPreview();
+    } else {
+      this.ui.previewToggleOn.classList.remove('active');
+      this.ui.previewToggleOff.classList.add('active');
+      this.ui.previewInfoPanel.classList.remove('open');
+      this.clearOverlay();
+      this.stopAnimation();
+    }
+  }
+
+  public async refreshPreview(): Promise<void> {
+    if (!this.isPreviewActive) return;
+    
+    const cm = this.getCanvasManager();
+    if (!cm) return;
+
+    const speed = parseFloat(this.ui.speedInput.value) || 10;
+    const density = this.state.fillEnabled 
+      ? parseFloat(this.ui.rasterDensityInput.value) 
+      : 0;
+    const rasterType = this.state.selectedRasterPattern || '';
+    const isFill = this.state.fillEnabled;
+
+    this.ui.previewDuration.textContent = 'Computing...';
+    
+    // Disable execute while computing new path
+    this.setExecuteButtonState(false);
+    this.stopAnimation();
+
+    try {
+      const response = await cm.previewPath(speed, rasterType, density, isFill);
+      
+      if (response.path && response.path.length > 0) {
+        this.handlePathData(response.path, response.duration);
+      } else {
+        this.ui.previewDuration.textContent = 'Waiting...';
+      }
+    } catch (e) {
+      console.error('Preview refresh error:', e);
+      this.ui.previewDuration.textContent = 'Error';
+      this.clearOverlay();
+    }
+  }
+
+  public handlePathFromWebSocket(previewData: { x: number[], y: number[] }): void {
+    if (!this.isPreviewActive) return;
+
+    const path: Position[] = [];
+    const len = Math.min(previewData.x.length, previewData.y.length);
+    for (let i = 0; i < len; i++) {
+      path.push({ x: previewData.x[i], y: previewData.y[i] });
     }
 
-    public async openPreview(): Promise<void> {
-        const cm = this.getCanvasManager();
-        if (!cm) return;
+    // Estimate duration
+    const speed = parseFloat(this.ui.speedInput.value) || 10;
+    let totalDistance = 0;
+    for (let i = 1; i < path.length; i++) {
+      const dx = path[i].x - path[i-1].x;
+      const dy = path[i].y - path[i-1].y;
+      totalDistance += Math.sqrt(dx * dx + dy * dy);
+    }
+    const duration = totalDistance / (speed * 10 || 1);
 
-        //Activate UI elements FIRST so they have dimensions in the DOM
-        this.ui.overlay.classList.add('active'); 
-        this.ui.previewPopup.classList.add('active');
+    this.handlePathData(path, duration);
+  }
 
-        //Set the video source for the background immediately
-        if (this.ui.video.srcObject) {
-            this.ui.previewVideo.srcObject = this.ui.video.srcObject;
-            this.ui.previewVideo.muted = true;
-            
-            try {
-                await this.ui.previewVideo.play();
-            } catch (e) {
-                console.warn("Preview video play error:", e);
-            }
-        }
-
-        //Perform layout calculation NOW that elements are visible
-        this.updateLayout();
-
-        //Update status and disable button while fetching
-        this.ui.previewTimeDisplay.textContent = "Requesting...";
-        this.ui.previewBtn.disabled = true;
-
-        //Fetch data and start
-        await this.updatePreviewData();
+  private handlePathData(videoPath: Position[], duration: number): void {
+    if (videoPath.length === 0) {
+      this.clearOverlay();
+      return;
     }
 
-    public closePreview(): void {
-        this.ui.previewPopup.classList.remove('active');
-        this.ui.overlay.classList.remove('active');
-        
-        //Stop the video stream to save resources
-        this.ui.previewVideo.srcObject = null;
-        
-        this.stopAnimation();
+    // Convert video coordinates to canvas coordinates
+    const video = this.ui.video;
+    const canvas = this.ui.previewOverlay;
+    const scaleX = canvas.width / (video.videoWidth || 1);
+    const scaleY = canvas.height / (video.videoHeight || 1);
 
-        // Re-enable the simulate button so the user can try again
-        this.ui.previewBtn.disabled = false;
+    this.pathData = videoPath.map(p => ({
+      x: p.x * scaleX,
+      y: p.y * scaleY
+    }));
+
+    this.durationSeconds = duration;
+    this.hasPreviewedCurrentDrawing = true;
+    
+    this.ui.previewDuration.textContent = `${duration.toFixed(1)}s`;
+
+    // Enable execute button
+    this.setExecuteButtonState(true);
+
+    this.drawPath();
+    this.startAnimation();
+  }
+
+  private drawPath(): void {
+    this.clearOverlay();
+    
+    if (this.pathData.length < 2) return;
+
+    const ctx = this.ctx;
+    ctx.save();
+
+    // Draw glow
+    ctx.strokeStyle = this.GLOW_COLOR;
+    ctx.lineWidth = this.GLOW_WIDTH;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.setLineDash([]);
+    this.drawPathLine(ctx);
+
+    // Draw main path
+    ctx.strokeStyle = this.PATH_COLOR;
+    ctx.lineWidth = this.PATH_WIDTH;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.setLineDash(this.DASH_PATTERN);
+    this.drawPathLine(ctx);
+
+    this.drawDirectionArrows(ctx);
+
+    ctx.restore();
+  }
+
+  private drawPathLine(ctx: CanvasRenderingContext2D): void {
+    ctx.beginPath();
+    ctx.moveTo(this.pathData[0].x, this.pathData[0].y);
+    for (let i = 1; i < this.pathData.length; i++) {
+      ctx.lineTo(this.pathData[i].x, this.pathData[i].y);
     }
+    ctx.stroke();
+  }
 
-    private updateLayout(): void {
-        const videoW = this.ui.video.videoWidth || 1;
-        const videoH = this.ui.video.videoHeight || 1;
-        const videoRatio = videoW / videoH;
+  private drawDirectionArrows(ctx: CanvasRenderingContext2D): void {
+    const arrowSpacing = 80;
+    let accumulatedDist = 0;
 
-        //Measure actual header height from DOM
-        const header = this.ui.previewPopup.querySelector('.preview-header');
-        const headerHeight = header ? header.getBoundingClientRect().height : 60;
+    ctx.fillStyle = this.PATH_COLOR;
+    ctx.setLineDash([]);
 
-        //Calculate positioning based on prepare popup
-        const prepareRect = this.ui.preparePopup.getBoundingClientRect();
-        const sidebarWidth = 65.5; 
-        const rightGap = window.innerWidth - prepareRect.right;
-        const targetLeft = sidebarWidth + rightGap;
+    for (let i = 1; i < this.pathData.length; i++) {
+      const p1 = this.pathData[i - 1];
+      const p2 = this.pathData[i];
+      
+      const dx = p2.x - p1.x;
+      const dy = p2.y - p1.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      
+      accumulatedDist += dist;
 
-        //Calculate available width for viewport content
-        const availableWidth = prepareRect.left - targetLeft - rightGap;
+      if (accumulatedDist >= arrowSpacing) {
+        accumulatedDist = 0;
         
-        //Start with maximum width, calculate height maintaining aspect ratio
-        let viewportW = availableWidth;
-        let viewportH = viewportW / videoRatio;
-
-        //Check vertical bounds (must fit in window with header)
-        const maxViewportHeight = window.innerHeight - (rightGap * 2) - headerHeight;
+        const angle = Math.atan2(dy, dx);
+        const arrowSize = 10;
         
-        if (viewportH > maxViewportHeight) {
-            //Height-constrained: recalculate width from max height
-            viewportH = maxViewportHeight;
-            viewportW = viewportH * videoRatio;
-        }
-
-        //Round to integers for pixel-perfect alignment
-        viewportW = Math.floor(viewportW);
-        viewportH = Math.floor(viewportH);
-
-        //Apply dimensions to popup (viewport + header)
-        this.ui.previewPopup.style.left = `${targetLeft}px`;
-        this.ui.previewPopup.style.top = `${prepareRect.top}px`;
-        this.ui.previewPopup.style.width = `${viewportW}px`;
-        this.ui.previewPopup.style.height = `${viewportH + headerHeight}px`;
-
-        //Set canvas internal resolution to match viewport exactly
-        this.ui.previewCanvas.width = viewportW;
-        this.ui.previewCanvas.height = viewportH;
-
-        //Calculate scale factors for coordinate transformation
-        this.scaleX = viewportW / videoW;
-        this.scaleY = viewportH / videoH;
-
-        //Update marker size with even integer snapping
-        const baseMarkerSize = 24; 
-        let scaledSize = Math.max(8, baseMarkerSize * (viewportW / 1920));
+        ctx.save();
+        ctx.translate(p2.x, p2.y);
+        ctx.rotate(angle);
         
-        //Force even number to prevent sub-pixel centering issues
-        scaledSize = Math.round(scaledSize);
-        if (scaledSize % 2 !== 0) scaledSize += 1;
-
-        this.markerSize = scaledSize;
-        this.ui.previewMarker.style.width = `${this.markerSize}px`;
-        this.ui.previewMarker.style.height = `${this.markerSize}px`;
-    }
-
-    public async updatePreviewData(): Promise<void> {
-        const cm = this.getCanvasManager();
-        if (!cm) return;
-
-        this.stopAnimation();
-
-        //Ensure layout is valid before processing
-        if (this.ui.previewPopup.classList.contains('active')) {
-            this.updateLayout();
-        }
-
-        const speed = parseFloat(this.ui.speedInput.value) || 10;
-        const density = this.state.fillEnabled ? parseFloat(this.ui.rasterDensityInput.value) : 10;
-        const rasterType = this.state.selectedRasterPattern || '';
-        const isFill = this.state.fillEnabled;
-
-        try {
-            //Send request to backend
-            //In REAL mode, this returns an empty path. In FAKE mode, it returns the path.
-            const response = await cm.previewPath(speed, rasterType, density, isFill);
-            
-            if (response.path && response.path.length > 0) {
-                // --- FAKE MODE DETECTED (Data came back in HTTP response) ---
-                this.pathData = response.path;
-                this.durationSeconds = response.duration;
-                this.ui.previewTimeDisplay.textContent = `Est. Time: ${this.durationSeconds.toFixed(1)}s`;
-                this.ui.previewBtn.disabled = false;
-                
-                this.drawPathOverlay(); 
-                this.startAnimation();
-            } else {
-                // --- REAL MODE (No data in HTTP response) ---
-                // We must wait for the WebSocket to deliver 'path_preview'
-                this.ui.previewTimeDisplay.textContent = "Computing (Waiting for Robot)...";
-                // Keep button disabled until WS data arrives
-                this.ui.previewBtn.disabled = true;
-            }
-
-        } catch (e) {
-            console.error(e);
-            this.ui.previewTimeDisplay.textContent = "Error";
-            this.ui.previewBtn.disabled = false;
-        }
-    }
-
-    /**
-     * Called by AppController when a 'path_preview' message arrives via WebSocket.
-     * format: { x: [1,2...], y: [3,4...] } (Structure of Arrays)
-     */
-    public handlePathFromWebSocket(previewData: { x: number[], y: number[] }): void {
-        if (!this.ui.previewPopup.classList.contains('active')) return;
-
-        // Convert SOA (Structure of Arrays) to AOS (Array of Objects)
-        const path: Position[] = [];
-        const len = Math.min(previewData.x.length, previewData.y.length);
-        
-        for (let i = 0; i < len; i++) {
-            path.push({ x: previewData.x[i], y: previewData.y[i] });
-        }
-
-        if (path.length === 0) return;
-
-        this.pathData = path;
-        
-        // Estimate duration based on simple distance calc (since robot didn't send duration)
-        const speed = parseFloat(this.ui.speedInput.value) || 10;
-        let totalDistance = 0;
-        for (let i = 1; i < path.length; i++) {
-            const dx = path[i].x - path[i-1].x;
-            const dy = path[i].y - path[i-1].y;
-            totalDistance += Math.sqrt(dx*dx + dy*dy);
-        }
-        
-        // Arbitrary scaling for duration display if speed is abstract
-        // If speed is mm/s and pixels are converted, this needs unit math. 
-        // For now, assuming pixels and 'speed' factor:
-        this.durationSeconds = totalDistance / (speed * 10 || 1); 
-
-        this.ui.previewTimeDisplay.textContent = `Ready`;
-        this.ui.previewBtn.disabled = false;
-
-        this.drawPathOverlay();
-        this.startAnimation();
-    }
-
-    private drawPathOverlay(): void {
-        const ctx = this.ui.previewCanvas.getContext('2d');
-        if (!ctx) return; 
-
-        // Clear canvas completely so the video element behind it shows through
-        ctx.clearRect(0, 0, this.ui.previewCanvas.width, this.ui.previewCanvas.height);
-        
-        if (this.pathData.length < 2) return;
-
         ctx.beginPath();
-        // Cyan path matching the robot's intent
-        ctx.strokeStyle = '#00ffff'; 
-        ctx.lineWidth = 2; 
-        ctx.lineJoin = 'round';
-        ctx.lineCap = 'round';
-
-        const start = this.pathData[0];
-        ctx.moveTo(start.x * this.scaleX, start.y * this.scaleY);
-
-        for (let i = 1; i < this.pathData.length; i++) {
-            const p = this.pathData[i];
-            ctx.lineTo(p.x * this.scaleX, p.y * this.scaleY);
-        }
-        ctx.stroke();
-    }
-
-    private startAnimation(): void {
-        this.isAnimating = true;
-        this.startTime = performance.now();
-        this.ui.previewMarker.style.display = 'block';
-        this.loop();
-    }
-
-    private stopAnimation(): void {
-        this.isAnimating = false;
-        if (this.animationFrameId) cancelAnimationFrame(this.animationFrameId);
-        this.ui.previewMarker.style.display = 'none';
-    }
-
-    private loop(): void {
-        if (!this.isAnimating || this.pathData.length === 0) return;
-
-        const now = performance.now();
-        const elapsed = (now - this.startTime) / 1000; 
-
-        // Avoid division by zero
-        const duration = this.durationSeconds > 0 ? this.durationSeconds : 1;
-
-        let progress = elapsed / duration;
-        if (progress >= 1) {
-            this.startTime = performance.now();
-            progress = 0;
-        }
-
-        const totalPoints = this.pathData.length;
-        const index = Math.min(Math.floor(progress * totalPoints), totalPoints - 1);
-        const point = this.pathData[index];
-
-        const domX = point.x * this.scaleX;
-        const domY = point.y * this.scaleY;
-
-        // Manual centering calculation
-        const offset = this.markerSize / 2;
+        ctx.moveTo(0, 0);
+        ctx.lineTo(-arrowSize, -arrowSize / 2);
+        ctx.lineTo(-arrowSize, arrowSize / 2);
+        ctx.closePath();
+        ctx.fill();
         
-        this.ui.previewMarker.style.left = `${domX - offset}px`;
-        this.ui.previewMarker.style.top = `${domY - offset}px`;
-
-        this.animationFrameId = requestAnimationFrame(() => this.loop());
+        ctx.restore();
+      }
     }
+  }
+
+  private startAnimation(): void {
+    if (this.pathData.length === 0 || this.durationSeconds <= 0) return;
+    
+    this.stopAnimation();
+    this.isAnimating = true;
+    this.animationStartTime = performance.now();
+    this.ui.previewMarker.style.display = 'block';
+    this.animationLoop();
+  }
+
+  private stopAnimation(): void {
+    this.isAnimating = false;
+    if (this.animationFrameId) {
+      cancelAnimationFrame(this.animationFrameId);
+      this.animationFrameId = null;
+    }
+    this.ui.previewMarker.style.display = 'none';
+  }
+
+  private animationLoop(): void {
+    if (!this.isAnimating || this.pathData.length === 0) return;
+
+    const now = performance.now();
+    const elapsed = (now - this.animationStartTime) / 1000;
+    let progress = elapsed / this.durationSeconds;
+    
+    if (progress >= 1) {
+      this.animationStartTime = performance.now();
+      progress = 0;
+    }
+
+    const totalPoints = this.pathData.length;
+    const index = Math.min(
+      Math.floor(progress * totalPoints), 
+      totalPoints - 1
+    );
+    const point = this.pathData[index];
+
+    // Convert canvas coordinates to DOM viewport coordinates
+    const canvasRect = this.ui.previewOverlay.getBoundingClientRect();
+    const scaleX = canvasRect.width / this.ui.previewOverlay.width;
+    const scaleY = canvasRect.height / this.ui.previewOverlay.height;
+    
+    const domX = point.x * scaleX;
+    const domY = point.y * scaleY;
+    
+    this.ui.previewMarker.style.left = `${domX}px`;
+    this.ui.previewMarker.style.top = `${domY}px`;
+
+    this.animationFrameId = requestAnimationFrame(() => this.animationLoop());
+  }
+
+  private clearOverlay(): void {
+    this.ctx.clearRect(0, 0, this.ui.previewOverlay.width, this.ui.previewOverlay.height);
+  }
+
+  public updateOverlaySize(): void {
+    const canvas = this.ui.previewOverlay;
+    const viewport = this.ui.viewport;
+    
+    canvas.width = viewport.offsetWidth;
+    canvas.height = viewport.offsetHeight;
+    
+    if (this.isPreviewActive && this.pathData.length > 0) {
+      this.drawPath();
+    }
+  }
+
+  public hasPreviewedCurrent(): boolean {
+    return this.hasPreviewedCurrentDrawing;
+  }
+
+  public resetPreviewState(): void {
+    this.hasPreviewedCurrentDrawing = false;
+    this.pathData = [];
+    this.durationSeconds = 0;
+    this.stopAnimation();
+    this.clearOverlay();
+    this.ui.previewDuration.textContent = '--';
+    
+    // Disable execute button
+    this.setExecuteButtonState(false);
+    this.ui.previewToggleOff.click();
+  }
+
+  public dispose(): void {
+    this.stopAnimation();
+    this.clearOverlay();
+  }
 }

--- a/frontend/src/features/settings/ModeManager.ts
+++ b/frontend/src/features/settings/ModeManager.ts
@@ -181,6 +181,7 @@ export class ModeManager {
         if (this.state.drawnShapeType) {
             // A shape already exists on canvas – lock tools, highlight the right button
             cm?.disableDrawing();
+            cm?.enableDrawing();
             this.ui.toggleButtons.forEach(btn => btn.classList.remove('selected'));
             this.highlightShapeBtn(this.state.drawnShapeType);
         } else if (this.state.selectedShape && this.state.selectedShape !== 'marker') {

--- a/frontend/src/services/WebSocketHandler.ts
+++ b/frontend/src/services/WebSocketHandler.ts
@@ -19,6 +19,11 @@ export interface WebSocketMessage {
     isTransformedViewOn: boolean;
     pathEvent: string | null;
     heat_markers?: { x: number, y: number }[];
+    
+    path_preview?: {
+        x: number[];
+        y: number[];
+    };
 }
 
 // Type for partial updates, any subset of WebSocketMessage

--- a/frontend/src/services/WebSocketHandler.ts
+++ b/frontend/src/services/WebSocketHandler.ts
@@ -24,6 +24,7 @@ export interface WebSocketMessage {
         x: number[];
         y: number[];
     };
+    preview_duration?: number;
 }
 
 // Type for partial updates, any subset of WebSocketMessage

--- a/frontend/src/styles/components/buttons.css
+++ b/frontend/src/styles/components/buttons.css
@@ -1,130 +1,7 @@
-/* frontend/src/styles/components/buttons.css */
-
 /* ============================================
-   TOGGLE SWITCH COMPONENTS
+   TOGGLE SWITCHES (LASER & ROBOT)
    ============================================ */
-
-/* --- Laser Toggle --- */
-#laser-toggle-container {
-  position: relative;
-  display: flex;
-  height: 100%;
-  width: 300px;
-  flex-shrink: 0;
-  user-select: none;
-}
-
-.laser-bg-section {
-  height: 100%;
-  width: 50%;
-  background-color: #172027;
-}
-
-#laser-off-bg {
-  background-color: #2c343b;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  padding-left: 15px;
-  transition: background-color 0.2s ease;
-}
-
-#laser-on-bg {
-  border-top-right-radius: 16px;
-  border-bottom-right-radius: 16px;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  padding-right: 15px;
-  background-color: #172027;
-  transition: background-color 0.2s ease;
-}
-
-#laser-center-box {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  height: 100%;
-  width: 185px;
-  border-radius: 18px;
-  background-color: #172027;
-  border: 2px solid #2c343b;
-  padding: 0 40px;
-  color: #e0f2e0;
-  font-size: 18px;
-  font-weight: bold;
-  z-index: 2;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-sizing: border-box;
-  transition: background-color 0.2s ease, border-color 0.2s ease;
-  cursor: pointer;
-  overflow: hidden;
-}
-
-#laser-slider {
-  position: absolute;
-  left: 3px;
-  top: 3px;
-  width: 40px;
-  height: calc(100% - 6px);
-  background-color: #e0f2e0;
-  border-radius: 14px;
-  transition: left 0.3s ease, background-color 0.2s ease;
-  z-index: 1;
-}
-
-#laser-text {
-  position: relative;
-  z-index: 2;
-}
-
-#laser-off-text,
-#laser-on-text {
-  position: absolute;
-  color: #e0f2e0;
-  font-size: 18px;
-  font-weight: bold;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 1;
-}
-
-#laser-off-text {
-  left: 15px;
-}
-
-#laser-on-text {
-  right: 15px;
-}
-
-/* Active State */
-#laser-toggle-container.active #laser-slider {
-  left: calc(100% - 43px);
-  background-color: #fff6f8;
-}
-
-#laser-toggle-container.active #laser-center-box {
-  background-color: #86140d;
-  border-color: #cb0e00;
-  color: #fff6f8;
-}
-
-#laser-toggle-container.active #laser-off-bg {
-  background-color: #172027;
-}
-
-#laser-toggle-container.active #laser-on-bg {
-  background-color: #cb0e00;
-}
-
-#laser-toggle-container.active #laser-on-text {
-  color: #fff6f8;
-}
-
-/* --- Robot Toggle --- */
+#laser-toggle-container,
 #robot-toggle-container {
   position: relative;
   display: flex;
@@ -134,15 +11,14 @@
   user-select: none;
 }
 
-.robot-bg-section {
+/* --- Toggle Backgrounds --- */
+.laser-bg-section, .robot-bg-section {
   height: 100%;
   width: 50%;
   background-color: #172027;
 }
 
-#robot-off-bg {
-  border-top-left-radius: 16px;
-  border-bottom-left-radius: 16px;
+#laser-off-bg, #robot-off-bg {
   background-color: #2c343b;
   display: flex;
   align-items: center;
@@ -151,7 +27,12 @@
   transition: background-color 0.2s ease;
 }
 
-#robot-on-bg {
+#robot-off-bg {
+  border-top-left-radius: 16px;
+  border-bottom-left-radius: 16px;
+}
+
+#laser-on-bg, #robot-on-bg {
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -160,7 +41,13 @@
   transition: background-color 0.2s ease;
 }
 
-#robot-center-box {
+#laser-on-bg {
+  border-top-right-radius: 16px;
+  border-bottom-right-radius: 16px;
+}
+
+/* --- Center Box (Slider Container) --- */
+#laser-center-box, #robot-center-box {
   position: absolute;
   top: 0;
   left: 50%;
@@ -184,7 +71,8 @@
   overflow: hidden;
 }
 
-#robot-slider {
+/* --- Sliders --- */
+#laser-slider, #robot-slider {
   position: absolute;
   left: 3px;
   top: 3px;
@@ -196,13 +84,14 @@
   z-index: 1;
 }
 
-#robot-text {
+/* --- Text Labels --- */
+#laser-text, #robot-text {
   position: relative;
   z-index: 2;
 }
 
-#robot-off-text,
-#robot-on-text {
+#laser-off-text, #laser-on-text,
+#robot-off-text, #robot-on-text {
   position: absolute;
   color: #e0f2e0;
   font-size: 18px;
@@ -212,40 +101,39 @@
   z-index: 1;
 }
 
-#robot-off-text {
-  left: 15px;
-}
+#laser-off-text, #robot-off-text { left: 15px; }
+#laser-on-text, #robot-on-text { right: 15px; }
 
-#robot-on-text {
-  right: 15px;
+/* --- Active States: Laser --- */
+#laser-toggle-container.active #laser-slider {
+  left: calc(100% - 43px);
+  background-color: #fff6f8;
 }
+#laser-toggle-container.active #laser-center-box {
+  background-color: #86140d;
+  border-color: #cb0e00;
+  color: #fff6f8;
+}
+#laser-toggle-container.active #laser-off-bg { background-color: #172027; }
+#laser-toggle-container.active #laser-on-bg { background-color: #cb0e00; }
+#laser-toggle-container.active #laser-on-text { color: #fff6f8; }
 
-/* Active State */
+/* --- Active States: Robot --- */
 #robot-toggle-container.active #robot-slider {
   left: calc(100% - 43px);
   background-color: #f2f1e0;
 }
-
 #robot-toggle-container.active #robot-center-box {
   background-color: #79420c;
   border-color: #fa8500;
   color: #f2f1e0;
 }
-
-#robot-toggle-container.active #robot-off-bg {
-  background-color: #172027;
-}
-
-#robot-toggle-container.active #robot-on-bg {
-  background-color: #fa8500;
-}
-
-#robot-toggle-container.active #robot-on-text {
-  color: #f2f1e0;
-}
+#robot-toggle-container.active #robot-off-bg { background-color: #172027; }
+#robot-toggle-container.active #robot-on-bg { background-color: #fa8500; }
+#robot-toggle-container.active #robot-on-text { color: #f2f1e0; }
 
 /* ============================================
-   ICON & MODE BUTTONS
+   ICON BUTTONS (Sidebar/Tools)
    ============================================ */
 .icon-btn {
   display: flex;
@@ -254,7 +142,6 @@
   width: 90%;
   aspect-ratio: 1 / 1;
   border-radius: 12px;
-  border: none;
   background-color: #2c343b;
   color: #e0f2e0;
   border: 3px solid transparent;
@@ -262,9 +149,7 @@
   cursor: pointer;
 }
 
-.icon-btn:hover {
-  filter: brightness(110%);
-}
+.icon-btn:hover { filter: brightness(110%); }
 
 .icon-btn.selected,
 .icon-btn:active {
@@ -278,18 +163,21 @@
   cursor: not-allowed;
   filter: grayscale(50%);
   pointer-events: none;
-  box-shadow: none;
   border-color: transparent;
+  box-shadow: none;
 }
 
-.icon-btn-stroke {
-  stroke: #e0f2e0;
-}
+.icon-btn-stroke { stroke: #e0f2e0; }
+.icon-btn-fill { fill: #e0f2e0; }
 
-.icon-btn-fill {
+#settingsBtn {
+  transition: all 0.08s ease-out;
   fill: #e0f2e0;
 }
 
+/* ============================================
+   MODE BUTTONS (Top Right)
+   ============================================ */
 .mode-btn {
   display: flex;
   align-items: center;
@@ -331,13 +219,8 @@
   stroke: none;
 }
 
-#settingsBtn {
-  transition: all 0.08s ease-out;
-  fill: #e0f2e0;
-}
-
 /* ============================================
-   ACTION BUTTONS (DRAWING/PREPARE/EXECUTE)
+   ACTION BUTTONS (DRAW/EXECUTE/CANCEL)
    ============================================ */
 .action-btn {
   display: flex;
@@ -350,7 +233,6 @@
   font-size: 14px;
   letter-spacing: 0.5px;
   text-transform: uppercase;
-  border: none;
   border-radius: 12px;
   cursor: pointer;
   transition: all 0.15s ease;
@@ -363,87 +245,51 @@
   flex-shrink: 0;
 }
 
-.action-btn:hover:not(:disabled) {
-  filter: brightness(115%);
-}
-
-.action-btn:active:not(:disabled) {
-  filter: brightness(95%);
-}
-
-.action-btn:disabled {
-  opacity: 0.3;
-  cursor: not-allowed;
-  filter: grayscale(50%);
-}
-
-.action-btn[data-state="drawing"] {
-  background-color: #fa8500;
-  color: #0f1419;
-  border-color: #fa8500;
-  fill: #0f1419;
-}
-
-.action-btn[data-state="drawing"]:hover {
-  filter: brightness(110%);
-}
-
-.action-btn-prepare {
-  background-color: #1a4d6b;
-  color: #e0f2e0;
-  fill: #e0f2e0;
-  width: fit-content;
-}
-
-.action-btn-prepare:hover:not(:disabled) {
-  background-color: #1a4d6b;
-}
-
-.action-btn-prepare:disabled {
-  background-color: #303d4b;
-  color: #e0f2e0;
-}
-
 .btn-icon {
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.btn-text {
-  line-height: 1;
+.btn-text { line-height: 1; }
+
+.action-btn:hover:not(:disabled) { filter: brightness(115%); }
+.action-btn:active:not(:disabled) { filter: brightness(95%); }
+.action-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+  filter: grayscale(50%);
 }
 
+/* State: Drawing */
+.action-btn[data-state="drawing"] {
+  background-color: #fa8500;
+  color: #0f1419;
+  border-color: #fa8500;
+  fill: #0f1419;
+}
+.action-btn[data-state="drawing"]:hover { filter: brightness(110%); }
+
+/* Variant: Prepare */
+.action-btn-prepare {
+  background-color: #1a4d6b;
+  width: fit-content;
+}
+.action-btn-prepare:hover:not(:disabled) { background-color: #1a4d6b; }
+.action-btn-prepare:disabled { background-color: #303d4b; }
+
+/* Variant: Execute */
 .action-btn-execute {
   background-color: #cb0e00;
   color: #fff6f8;
   fill: #fff6f8;
 }
+.action-btn-execute:hover:not(:disabled) { background-color: #cb0e00; }
+.action-btn-execute:disabled { background-color: #303d4b; color: #e0f2e0; fill: #e0f2e0; }
 
-.action-btn-execute:hover:not(:disabled) {
-  background-color: #cb0e00;
-  color: #fff6f8;
-  fill: #fff6f8;
-}
-
-.action-btn-execute:disabled {
-  background-color: #303d4b;
-  color: #e0f2e0;
-  fill: #e0f2e0;
-}
-
-.action-btn-cancel {
-  background-color: #303d4b;
-  color: #e0f2e0;
-  fill: #e0f2e0
-}
-
-.action-btn-cancel:hover:not(:disabled) {
-  background-color: #303d4b;
-  fill: #e0f2e0;
-  color: #e0f2e0;
-}
-
+/* Variant: Cancel */
+.action-btn-cancel,
+.action-btn-cancel:hover:not(:disabled),
 .action-btn-cancel:disabled {
   background-color: #303d4b;
   color: #e0f2e0;

--- a/frontend/src/styles/components/buttons.css
+++ b/frontend/src/styles/components/buttons.css
@@ -1,3 +1,5 @@
+/* frontend/src/styles/components/buttons.css */
+
 /* ============================================
    TOGGLE SWITCH COMPONENTS
    ============================================ */

--- a/frontend/src/styles/components/preparePage.css
+++ b/frontend/src/styles/components/preparePage.css
@@ -76,7 +76,7 @@
   justify-content: center;
   align-items: center;
   padding: 1.5rem 2rem;
-  gap: 2rem;
+  gap: 1rem;
   box-sizing: border-box;
 }
 
@@ -85,32 +85,41 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: 1rem;
 }
 
 .input-label {
   display: block;
   color: #E0F2E0;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
   font-family: 'IBM Plex Sans', sans-serif;
   font-weight: 500;
   font-size: 1.2rem;
 }
 
+/* Speed Input - NO container, just label and input */
+.speed-input-wrapper {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .input-wrapper {
   position: relative;
   height: fit-content;
-  width: 70%;
+  width: 100%;
 }
 
 .styled-input {
-  background: #161b22;
+  background: #161b2296;
   border: 2px solid #2c343b;
   color: #E0F2E0;
-  padding: 15px;
+  padding: 12px 15px;
   border-radius: 8px;
   width: 100%;
   font-family: 'IBM Plex Sans', sans-serif;
-  font-size: 1.3rem;
+  font-size: 1.1rem;
   text-align: center;
   box-sizing: border-box;
   transition: border-color 0.2s;
@@ -136,105 +145,92 @@
 }
 
 /* ============================================
-   ACCORDION & SEGMENTED CONTROLS
+   FILL SHAPE TOGGLE CONTAINER
    ============================================ */
-.fill-accordion-container {
+.fill-toggle-container {
   width: 100%;
-  margin-top: 20px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-/* Toggle Button */
-.fill-accordion-toggle {
-  width: 70%;
-  background-color: #161b22;
+  background-color: #161b2296;
   border: 2px solid #2c343b;
   border-radius: 8px;
   padding: 12px 20px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  color: #e0f2e0;
 }
 
-.fill-accordion-toggle:hover {
-  border-color: #e0f2e0;
-  background-color: #1c2128;
-  filter: none;
+.fill-toggle-container .input-label {
+  margin-bottom: 0;
 }
 
-.fill-accordion-toggle.active {
-  background-color: #2c343b;
-  border-color: #e0f2e0;
-  color: #e0f2e0;
-}
-
-.fill-toggle-text {
-  font-family: 'IBM Plex Sans', sans-serif;
-  font-weight: 700;
-  font-size: 16px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.fill-toggle-icon {
+/* ============================================
+   ACCORDION & SEGMENTED CONTROLS
+   ============================================ */
+.fill-accordion-container {
+  width: 100%;
   display: flex;
-  align-items: center;
-  transition: transform 0.3s ease;
-  color: #5c6b75;
+  flex-direction: column;
 }
 
-.fill-accordion-toggle.active .fill-toggle-icon {
-  transform: rotate(180deg);
-  color: #e0f2e0;
-}
-
-/* Accordion Panel */
+/* Fill Settings Panel */
 .fill-settings-panel {
-  width: 70%;
+  width: 100%;
   max-height: 0;
   overflow: hidden;
-  background-color: #151a1f;
+  background-color: #161b2296;
   border-radius: 8px;
   transition: max-height 0.3s ease-out, opacity 0.3s ease;
   opacity: 0;
   border: 2px solid transparent;
-  margin-top: 5px;
 }
 
 .fill-settings-panel.open {
-  max-height: 200px;
+  max-height: 250px;
   opacity: 1;
   border-color: #2c343b;
 }
 
 .fill-settings-inner {
-  padding: 15px;
+  padding: 20px;
   display: flex;
   flex-direction: column;
-  gap: 15px;
+  gap: 18px;
   align-items: center;
 }
 
-/* Segmented Control (Line/Spiral) */
+/* Raster Pattern Section */
+.raster-pattern-section {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.raster-pattern-section .fill-setting-label {
+  font-size: 14px;
+  color: #e0f2e0;
+  font-weight: 600;
+  text-align: center;
+}
+
+/* Segmented Control (Off/On and Line/Spiral) */
 .segment-control {
   display: flex;
-  width: 100%;
   background-color: #0f1419;
   border-radius: 6px;
   padding: 3px;
   border: 1px solid #2c343b;
 }
 
+.segment-control.raster-pattern-control {
+  width: 80%;
+}
+
 .segment-btn {
   flex: 1;
   background: transparent;
   border: none;
-  padding: 8px;
+  padding: 10px 16px;
   color: #5c6b75;
   font-family: 'IBM Plex Sans', sans-serif;
   font-weight: 600;
@@ -242,6 +238,7 @@
   border-radius: 4px;
   transition: all 0.2s ease;
   text-transform: uppercase;
+  cursor: pointer;
 }
 
 .segment-btn:hover {
@@ -255,33 +252,51 @@
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
 }
 
-/* Density Inputs */
+/* Density Section */
+.density-section {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
 .density-wrapper {
+  width: 80%;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  gap: 10px;
+  justify-content: center;
+  gap: 15px;
+  background-color: #0f1419;
+  border: 1px solid #2c343b;
+  border-radius: 6px;
+  padding: 10px 15px;
 }
 
 .fill-setting-label {
   margin: 0;
-  font-size: 13px;
-  color: #9aa5b1;
-  font-weight: 500;
+  font-size: 14px;
+  color: #e0f2e0;
+  font-weight: 600;
+}
+
+.density-wrapper .fill-setting-label {
+  flex-shrink: 0;
 }
 
 .styled-input-density {
   width: 80px;
-  padding: 8px;
+  padding: 8px 12px;
   font-size: 14px;
-  background-color: #0f1419;
+  background-color: #161b22;
   border: 2px solid #2c343b;
   color: #E0F2E0;
-  border-radius: 8px;
+  border-radius: 6px;
   text-align: center;
-  box-sizing: content-box;
+  box-sizing: border-box;
   transition: border-color 0.2s;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 500;
 }
 
 .styled-input-density:focus {
@@ -294,4 +309,39 @@
 .styled-input-density::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
+}
+
+/* ============================================
+   PREVIEW PATH BUTTON
+   ============================================ */
+.preview-action-container {
+  width: 100%;
+  margin-bottom: 0;
+  display: flex;
+  justify-content: center;
+}
+
+#previewPathBtn {
+  width: 100%;
+  background-color: #1c2128;
+  border: 2px solid #2c343b;
+  color: #e0f2e0;
+  fill: #e0f2e0;
+  transition: all 0.2s ease;
+}
+
+#previewPathBtn:hover:not(:disabled) {
+  background-color: rgb(46, 53, 65);
+  border-color: #e0f2e0;
+  filter: none;
+}
+
+#previewPathBtn:active:not(:disabled) {
+  background-color: #0f1419;
+}
+
+#previewPathBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  border-color: #2c343b;
 }

--- a/frontend/src/styles/components/preparePage.css
+++ b/frontend/src/styles/components/preparePage.css
@@ -3,7 +3,6 @@
    ============================================ */
 #preparePopup {
   position: absolute;
-  z-index: 101;
   top: 10%;
   right: 3%;
   width: fit-content;
@@ -16,12 +15,15 @@
   flex-direction: column;
   overflow: hidden;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  /* Layout positioning variable */
+  --popup-edge-offset: 10px;
 }
 
 #preparePopup.active {
   display: flex;
 }
 
+/* --- Header --- */
 .prepare-header {
   display: flex;
   justify-content: space-between;
@@ -51,6 +53,13 @@
   transition: all 0.15s ease-out;
 }
 
+#prepareCloseBtn svg {
+  fill: #e0f2e0;
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+}
+
 #prepareCloseBtn:hover {
   filter: brightness(110%);
 }
@@ -61,13 +70,7 @@
   box-shadow: inset 2px 2px 8px rgba(0, 0, 0, 0.5);
 }
 
-#prepareCloseBtn svg {
-  fill: #e0f2e0;
-  width: 22px;
-  height: 22px;
-  flex-shrink: 0;
-}
-
+/* --- Body & Layout --- */
 .prepare-body {
   display: flex;
   flex-grow: 1;
@@ -85,57 +88,297 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1rem;
+  gap: 12px;
 }
 
-.input-label {
-  display: block;
-  color: #E0F2E0;
-  margin-bottom: 0.5rem;
-  font-family: 'IBM Plex Sans', sans-serif;
-  font-weight: 500;
-  font-size: 1.2rem;
-}
-
-.speed-input-wrapper {
+/* --- Common Input Wrappers --- */
+.setting-row-wrapper {
   width: 100%;
+  height: 54px;
   display: flex;
-  flex-direction: column;
+  justify-content: space-between;
   align-items: center;
-}
-
-.input-wrapper {
-  position: relative;
-  height: fit-content;
-  width: 100%;
-}
-
-.styled-input {
-  background: #161b2296;
+  background-color: #161b2296;
   border: 2px solid #2c343b;
-  color: #E0F2E0;
-  padding: 12px 15px;
   border-radius: 8px;
-  width: 100%;
-  font-family: 'IBM Plex Sans', sans-serif;
-  font-size: 1.1rem;
-  text-align: center;
+  padding: 0 16px;
   box-sizing: border-box;
   transition: border-color 0.2s;
 }
 
-.styled-input:focus {
+.setting-row-wrapper:hover {
+  border-color: #455256;
+}
+
+.secondary-wrapper {
+  background-color: #0f1419;
+  border: 1px solid #2c343b;
+  height: 48px;
+}
+
+.settings-group-container {
+  width: 100%;
+  background-color: #161b2296;
+  border: 2px solid #2c343b;
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-sizing: border-box;
+}
+
+/* --- Labels & Inputs --- */
+.row-label {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 600;
+  font-size: 14px;
+  color: #E0F2E0;
+  margin: 0;
+  white-space: nowrap;
+}
+
+.input-label, 
+.fill-setting-label {
+  display: block;
+  color: #E0F2E0;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 600;
+}
+
+.input-label {
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+  font-size: 1.2rem;
+}
+
+.fill-setting-label {
+  font-size: 14px;
+  margin: 0;
+}
+
+/* Numeric Inputs */
+.row-input,
+.styled-input, 
+.styled-input-density {
+  background-color: #0f1419;
+  border: 1px solid #2c343b;
+  color: #E0F2E0;
+  border-radius: 6px;
+  text-align: center;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 500;
+  transition: all 0.2s;
+}
+
+.row-input {
+  width: 80px;
+  padding: 8px 10px;
+  font-size: 14px;
+}
+
+.styled-input {
+  width: 100%;
+  padding: 12px 15px;
+  font-size: 1.1rem;
+  background: #161b2296;
+  border-width: 2px;
+}
+
+.styled-input-density {
+  width: 80px;
+  padding: 8px 12px;
+  font-size: 14px;
+  background-color: #161b22;
+  border-width: 2px;
+}
+
+.secondary-wrapper .row-input {
+  background-color: #161b22;
+}
+
+.row-input:focus,
+.styled-input:focus,
+.styled-input-density:focus {
   outline: none;
   border-color: #e0f2e0;
   background: #1c2128;
 }
 
-.styled-input::-webkit-outer-spin-button,
-.styled-input::-webkit-inner-spin-button {
+/* Remove Spinners */
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
 
+/* --- Segmented Controls (Toggles) --- */
+.segment-control {
+  display: flex;
+  background-color: #0f1419;
+  border-radius: 6px;
+  padding: 2px;
+  border: 1px solid #2c343b;
+  height: 36px;
+}
+
+.segment-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  padding: 0 16px;
+  color: #5c6b75;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 600;
+  font-size: 13px;
+  border-radius: 4px;
+  transition: all 0.2s ease;
+  text-transform: uppercase;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.segment-btn:hover {
+  color: #e0f2e0;
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.segment-btn.active {
+  background-color: #2c343b;
+  color: #e0f2e0;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+}
+
+.fill-control, .preview-control { width: 120px; }
+.raster-control { width: 140px; }
+
+/* --- Fill Settings Panel (Accordion) --- */
+.fill-accordion-container {
+  width: 100%;
+}
+
+.fill-settings-panel {
+  width: 100%;
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height 0.3s ease-out, opacity 0.3s ease;
+}
+
+.fill-settings-panel.open {
+  max-height: 250px;
+  opacity: 1;
+}
+
+.fill-settings-inner {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* --- Preview Info Panel (Inside Prepare Modal) --- */
+.preview-action-container {
+  width: 100%;
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid #2c343b;
+  display: flex;
+  flex-direction: column;
+}
+
+.preview-wrapper {
+  background-color: #1c2128;
+}
+
+.preview-wrapper:hover {
+  border-color: #e0f2e0;
+}
+
+.preview-info-panel {
+  width: 100%;
+  max-height: 0;
+  overflow: hidden;
+  background-color: #161b2296;
+  border-radius: 8px;
+  transition: max-height 0.3s ease-out, opacity 0.3s ease;
+  opacity: 0;
+  border: 2px solid transparent;
+}
+
+.preview-info-panel.open {
+  max-height: 150px;
+  opacity: 1;
+  border-color: #2c343b;
+  margin-top: 8px;
+}
+
+.preview-info-inner {
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.preview-duration-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 0;
+}
+
+.preview-duration-label {
+  color: #e0f2e0;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.preview-duration-value {
+  color: #e0f2e0;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: 0.5px;
+}
+
+.preview-info-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 12px;
+  background-color: #0f1419;
+  border-radius: 6px;
+  border: 1px solid #2c343b;
+}
+
+.preview-info-icon {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background-color: #2c343b;
+  color: #e0f2e0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.preview-info-text {
+  color: #e0f2e0b6;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 12px;
+  line-height: 1.4;
+  white-space: normal;
+  max-width: 280px;
+}
+
+/* --- Action Buttons Layout (Grid/Flex) --- */
 #bottomButtons {
   display: flex;
   flex-direction: column;
@@ -151,246 +394,17 @@
   width: 100%;
 }
 
-/* Override button styles for this specific menu to ensure uniform sizing */
 #bottomButtons .action-btn {
   height: 50px;
   margin: 0;
   flex-shrink: 0;
 }
 
-/* Top button fills width */
-.full-width-btn {
-  width: 100%;
-}
-
-/* Bottom buttons split width 50/50 */
-.half-width-btn {
-  flex: 1;
-  width: 50%;
-}
+.full-width-btn { width: 100%; }
+.half-width-btn { flex: 1; width: 50%; }
 
 #bottomButtons .action-btn-prepare,
 #bottomButtons .action-btn-execute,
 #bottomButtons .action-btn-cancel {
   width: auto;
 }
-
-/* ============================================
-   FILL SHAPE TOGGLE CONTAINER
-   ============================================ */
-.fill-toggle-container {
-  width: 100%;
-  background-color: #161b2296;
-  border: 2px solid #2c343b;
-  border-radius: 8px;
-  padding: 12px 20px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.fill-toggle-container .input-label {
-  margin-bottom: 0;
-}
-
-/* ============================================
-   ACCORDION & SEGMENTED CONTROLS
-   ============================================ */
-.fill-accordion-container {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-}
-
-/* Fill Settings Panel */
-.fill-settings-panel {
-  width: 100%;
-  max-height: 0;
-  overflow: hidden;
-  background-color: #161b2296;
-  border-radius: 8px;
-  transition: max-height 0.3s ease-out, opacity 0.3s ease;
-  opacity: 0;
-  border: 2px solid transparent;
-}
-
-.fill-settings-panel.open {
-  max-height: 250px;
-  opacity: 1;
-  border-color: #2c343b;
-}
-
-.fill-settings-inner {
-  padding: 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-  align-items: center;
-}
-
-/* Raster Pattern Section */
-.raster-pattern-section {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 10px;
-}
-
-.raster-pattern-section .fill-setting-label {
-  font-size: 14px;
-  color: #e0f2e0;
-  font-weight: 600;
-  text-align: center;
-}
-
-/* Segmented Control (Off/On and Line/Spiral) */
-.segment-control {
-  display: flex;
-  background-color: #0f1419;
-  border-radius: 6px;
-  padding: 3px;
-  border: 1px solid #2c343b;
-}
-
-.segment-control.raster-pattern-control {
-  width: 80%;
-}
-
-.segment-btn {
-  flex: 1;
-  background: transparent;
-  border: none;
-  padding: 10px 16px;
-  color: #5c6b75;
-  font-family: 'IBM Plex Sans', sans-serif;
-  font-weight: 600;
-  font-size: 13px;
-  border-radius: 4px;
-  transition: all 0.2s ease;
-  text-transform: uppercase;
-  cursor: pointer;
-}
-
-.segment-btn:hover {
-  color: #e0f2e0;
-  background-color: rgba(255, 255, 255, 0.05);
-}
-
-.segment-btn.active {
-  background-color: #2c343b;
-  color: #e0f2e0;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-}
-
-/* Density Section */
-.density-section {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 10px;
-}
-
-.density-wrapper {
-  width: 80%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 15px;
-  background-color: #0f1419;
-  border: 1px solid #2c343b;
-  border-radius: 6px;
-  padding: 10px 15px;
-}
-
-.fill-setting-label {
-  margin: 0;
-  font-size: 14px;
-  color: #e0f2e0;
-  font-weight: 600;
-}
-
-.density-wrapper .fill-setting-label {
-  flex-shrink: 0;
-}
-
-.styled-input-density {
-  width: 80px;
-  padding: 8px 12px;
-  font-size: 14px;
-  background-color: #161b22;
-  border: 2px solid #2c343b;
-  color: #E0F2E0;
-  border-radius: 6px;
-  text-align: center;
-  box-sizing: border-box;
-  transition: border-color 0.2s;
-  font-family: 'IBM Plex Sans', sans-serif;
-  font-weight: 500;
-}
-
-.styled-input-density:focus {
-  outline: none;
-  border-color: #e0f2e0;
-  background: #1c2128;
-}
-
-.styled-input-density::-webkit-outer-spin-button,
-.styled-input-density::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-/* ============================================
-   PREVIEW PATH BUTTON
-   ============================================ */
-/* --- Preview Path Button --- */
-.preview-action-container {
-  width: 100%;
-  margin-top: 15px;
-  padding-top: 15px;
-  border-top: 1px solid #2c343b;
-  display: flex;
-  justify-content: center;
-}
-
-#previewPathBtn {
-  width: 100%;
-  background-color: #1c2128;
-  border: 2px solid #2c343b;
-  color: #e0f2e0;
-  fill: #e0f2e0;
-  transition: all 0.2s ease;
-}
-
-#previewPathBtn:hover:not(:disabled) {
-  background-color: rgb(46, 53, 65);
-  border-color: #e0f2e0;
-  filter: none;
-}
-
-#previewPathBtn:active:not(:disabled) {
-  background-color: #0f1419;
-}
-
-#previewPathBtn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  border-color: #2c343b;
-}
-
-
-.fill-header {
-  width: 70%;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 5px;
-}
-
-.fill-accordion-container .segment-control {
-    background-color: #0f1419;
-    border: 1px solid #2c343b;
-}
-

--- a/frontend/src/styles/components/preparePage.css
+++ b/frontend/src/styles/components/preparePage.css
@@ -97,7 +97,6 @@
   font-size: 1.2rem;
 }
 
-/* Speed Input - NO container, just label and input */
 .speed-input-wrapper {
   width: 100%;
   display: flex;
@@ -139,13 +138,12 @@
 
 #bottomButtons {
   display: flex;
-  flex-direction: column; /* Stack vertically */
+  flex-direction: column;
   gap: 12px;
   width: 100%;
   margin-top: 10px;
 }
 
-/* NEW: Layout for the bottom row (Cancel + Execute) */
 .bottom-btn-row {
   display: flex;
   flex-direction: row;
@@ -155,7 +153,7 @@
 
 /* Override button styles for this specific menu to ensure uniform sizing */
 #bottomButtons .action-btn {
-  height: 50px; /* Fixed uniform height */
+  height: 50px;
   margin: 0;
   flex-shrink: 0;
 }
@@ -171,11 +169,10 @@
   width: 50%;
 }
 
-/* Remove default width constraints from specific button types in this context */
 #bottomButtons .action-btn-prepare,
 #bottomButtons .action-btn-execute,
 #bottomButtons .action-btn-cancel {
-  width: auto; /* Let flexbox handle width */
+  width: auto;
 }
 
 /* ============================================

--- a/frontend/src/styles/components/preparePage.css
+++ b/frontend/src/styles/components/preparePage.css
@@ -314,9 +314,12 @@
 /* ============================================
    PREVIEW PATH BUTTON
    ============================================ */
+/* --- Preview Path Button --- */
 .preview-action-container {
   width: 100%;
-  margin-bottom: 0;
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid #2c343b;
   display: flex;
   justify-content: center;
 }
@@ -345,3 +348,18 @@
   cursor: not-allowed;
   border-color: #2c343b;
 }
+
+
+.fill-header {
+  width: 70%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 5px;
+}
+
+.fill-accordion-container .segment-control {
+    background-color: #0f1419;
+    border: 1px solid #2c343b;
+}
+

--- a/frontend/src/styles/components/preparePage.css
+++ b/frontend/src/styles/components/preparePage.css
@@ -319,7 +319,6 @@ input::-webkit-inner-spin-button {
   padding: 16px 20px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
 }
 
 .preview-duration-row {
@@ -327,6 +326,7 @@ input::-webkit-inner-spin-button {
   justify-content: space-between;
   align-items: center;
   padding: 10px 0;
+  padding-top: 0;
 }
 
 .preview-duration-label {

--- a/frontend/src/styles/components/preparePage.css
+++ b/frontend/src/styles/components/preparePage.css
@@ -139,9 +139,43 @@
 
 #bottomButtons {
   display: flex;
+  flex-direction: column; /* Stack vertically */
+  gap: 12px;
+  width: 100%;
+  margin-top: 10px;
+}
+
+/* NEW: Layout for the bottom row (Cancel + Execute) */
+.bottom-btn-row {
+  display: flex;
   flex-direction: row;
-  gap: 40px;
-  height: 70px;
+  gap: 12px;
+  width: 100%;
+}
+
+/* Override button styles for this specific menu to ensure uniform sizing */
+#bottomButtons .action-btn {
+  height: 50px; /* Fixed uniform height */
+  margin: 0;
+  flex-shrink: 0;
+}
+
+/* Top button fills width */
+.full-width-btn {
+  width: 100%;
+}
+
+/* Bottom buttons split width 50/50 */
+.half-width-btn {
+  flex: 1;
+  width: 50%;
+}
+
+/* Remove default width constraints from specific button types in this context */
+#bottomButtons .action-btn-prepare,
+#bottomButtons .action-btn-execute,
+#bottomButtons .action-btn-cancel {
+  width: auto; /* Let flexbox handle width */
 }
 
 /* ============================================

--- a/frontend/src/styles/components/previewPage.css
+++ b/frontend/src/styles/components/previewPage.css
@@ -1,0 +1,165 @@
+/* frontend/src/styles/components/previewPage.css */
+
+/* ============================================
+   PREVIEW PATH MODAL
+   ============================================ */
+
+/* Note: Top/Left/Width/Height are set by PreviewManager.ts 
+   to ensure the Aspect Ratio exactly matches the video feed
+   and to align it with the Prepare Menu.
+*/
+#previewPopup {
+  position: fixed;
+  z-index: 101; 
+  display: none;
+  flex-direction: column;
+  
+  background-color: #000; /* Pure black background for the container */
+  border: 2px solid #2c343b;
+  border-radius: 16px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.9);
+  color: #e0f2e0;
+  overflow: hidden;
+}
+
+#previewPopup.active {
+  display: flex;
+}
+
+/* --- Header Section --- */
+.preview-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background-color: #151b21;
+  border-bottom: 2px solid #2c343b;
+  flex-shrink: 0;
+}
+
+.preview-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.preview-info h3 {
+  margin: 0;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 20px;
+  color: #e0f2e0;
+}
+
+/* The time display text */
+#previewTimeDisplay {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 14px;
+  color: #70ff57; /* Green accent */
+  font-weight: 500;
+  letter-spacing: 0.5px;
+  margin-left: 0; 
+}
+
+/* --- Close Button --- */
+#previewCloseBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background-color: #2c343b;
+  color: #e0f2e0;
+  border: 3px solid transparent;
+  transition: all 0.15s ease-out;
+  cursor: pointer;
+}
+
+#previewCloseBtn:hover {
+  filter: brightness(110%);
+}
+
+#previewCloseBtn:active {
+  background-color: #455256;
+  border-color: #e0f2e0;
+  box-shadow: inset 2px 2px 8px rgba(0, 0, 0, 0.5);
+}
+
+#previewCloseBtn svg {
+  fill: #e0f2e0;
+  stroke: #e0f2e0;
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+}
+
+/* --- Viewport Area --- */
+.preview-viewport {
+  position: relative;
+  flex-grow: 1;
+  width: 100%;
+  height: 100%;
+  
+  /* Background Snapshot Handling */
+  background-color: #000;
+  
+  /* CRITICAL FIX: Forces the snapshot to stretch exactly like the main video.
+     This ensures the aspect ratio distortion matches the calculated path. */
+  background-size: 100% 100%; 
+  background-repeat: no-repeat;
+  background-position: center;
+  
+  overflow: hidden;
+}
+
+/* The Canvas layer for drawing the path lines */
+#previewCanvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 2;
+  pointer-events: none;
+}
+
+/* --- Simulation Marker (The moving dot) --- */
+#previewMarker {
+  position: absolute;
+  z-index: 10;
+  display: none;
+  pointer-events: none;
+  
+  /* Visuals */
+  background-color: transparent;
+  border: 3px solid #70ff57; /* Reduced to 2px for cleaner look at scale */
+  border-radius: 50%;
+  
+  /* Center pivot */
+  transform: translate(-50%, -50%);
+}
+
+.fill-header {
+  width: 70%; /* Matches input width */
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 5px;
+}
+
+/* Ensure segments inside the prepare menu look consistent */
+.fill-accordion-container .segment-control {
+    background-color: #0f1419;
+    border: 1px solid #2c343b;
+}
+
+/* --- Preview Path Button --- */
+.preview-action-container {
+  width: 100%;
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid #2c343b;
+  display: flex;
+  justify-content: center;
+}

--- a/frontend/src/styles/components/previewPage.css
+++ b/frontend/src/styles/components/previewPage.css
@@ -14,7 +14,7 @@
   display: none;
   flex-direction: column;
   
-  background-color: #000; /* Pure black background for the container */
+  background-color: #000;
   border: 2px solid #2c343b;
   border-radius: 16px;
   box-shadow: 0 20px 50px rgba(0, 0, 0, 0.9);
@@ -55,7 +55,7 @@
 #previewTimeDisplay {
   font-family: 'IBM Plex Sans', sans-serif;
   font-size: 14px;
-  color: #70ff57; /* Green accent */
+  color: #70ff57;
   font-weight: 500;
   letter-spacing: 0.5px;
   margin-left: 0; 
@@ -100,11 +100,8 @@
   flex-grow: 1;
   width: 100%;
   height: 100%;
-  
-  /* Background Snapshot Handling */
   background-color: #000;
-  
-  /* CRITICAL FIX: Forces the snapshot to stretch exactly like the main video.
+  /* Forces the snapshot to stretch exactly like the main video.
      This ensures the aspect ratio distortion matches the calculated path. */
   background-size: 100% 100%; 
   background-repeat: no-repeat;
@@ -130,36 +127,8 @@
   z-index: 10;
   display: none;
   pointer-events: none;
-  
-  /* Visuals */
   background-color: transparent;
-  border: 3px solid #70ff57; /* Reduced to 2px for cleaner look at scale */
+  border: 3px solid #70ff57;
   border-radius: 50%;
-  
-  /* Center pivot */
   transform: translate(-50%, -50%);
-}
-
-.fill-header {
-  width: 70%; /* Matches input width */
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 5px;
-}
-
-/* Ensure segments inside the prepare menu look consistent */
-.fill-accordion-container .segment-control {
-    background-color: #0f1419;
-    border: 1px solid #2c343b;
-}
-
-/* --- Preview Path Button --- */
-.preview-action-container {
-  width: 100%;
-  margin-top: 15px;
-  padding-top: 15px;
-  border-top: 1px solid #2c343b;
-  display: flex;
-  justify-content: center;
 }

--- a/frontend/src/styles/components/previewPage.css
+++ b/frontend/src/styles/components/previewPage.css
@@ -101,12 +101,11 @@
   left: 0;
   width: 100%;
   height: 100%;
-  object-fit: fill;   /* Crucial: matches main video distortion so paths align */
-  z-index: 1;         /* Sit behind the canvas (which is z-index: 2) */
+  object-fit: fill;
+  z-index: 1;
   pointer-events: none;
 }
 
-/* Update this existing class to remove the background image logic */
 .preview-viewport {
   position: relative;
   flex-grow: 1;
@@ -114,7 +113,6 @@
   height: 100%;
   background-color: #000;
   overflow: hidden;
-  /* Remove background-size, background-repeat, etc. */
 }
 
 /* The Canvas layer for drawing the path lines */
@@ -137,5 +135,5 @@
   background-color: transparent;
   border: 3px solid #70ff57;
   border-radius: 50%;
-  transform: translate(-50%, -50%);
+  box-sizing: border-box;
 }

--- a/frontend/src/styles/components/previewPage.css
+++ b/frontend/src/styles/components/previewPage.css
@@ -1,139 +1,38 @@
-/* frontend/src/styles/components/previewPage.css */
+/* ============================================
+   PREVIEW OVERLAY (CAD-style toolpath)
+   ============================================ */
+#previewOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  display: block;
+}
 
 /* ============================================
-   PREVIEW PATH MODAL
+   PREVIEW TOGGLE (In Menu)
    ============================================ */
-
-/* Note: Top/Left/Width/Height are set by PreviewManager.ts 
-   to ensure the Aspect Ratio exactly matches the video feed
-   and to align it with the Prepare Menu.
-*/
-#previewPopup {
-  position: fixed;
-  z-index: 101; 
-  display: none;
-  flex-direction: column;
-  
-  background-color: #000;
+.preview-toggle-container {
+  width: 100%;
+  background-color: #161b2296;
   border: 2px solid #2c343b;
-  border-radius: 16px;
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.9);
-  color: #e0f2e0;
-  overflow: hidden;
-}
-
-#previewPopup.active {
-  display: flex;
-}
-
-/* --- Header Section --- */
-.preview-header {
+  border-radius: 8px;
+  padding: 12px 20px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1rem 1.5rem;
-  background-color: #151b21;
-  border-bottom: 2px solid #2c343b;
-  flex-shrink: 0;
+  margin-top: 15px;
+  border-top: 1px solid #2c343b;
+  padding-top: 15px;
 }
 
-.preview-info {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+.preview-toggle-container .input-label {
+  margin-bottom: 0;
 }
 
-.preview-info h3 {
-  margin: 0;
-  font-family: 'IBM Plex Sans', sans-serif;
-  font-weight: 700;
-  font-size: 20px;
-  color: #e0f2e0;
-}
-
-/* The time display text */
-#previewTimeDisplay {
-  font-family: 'IBM Plex Sans', sans-serif;
-  font-size: 14px;
-  color: #e0f2e0b6;
-  font-weight: 500;
-  letter-spacing: 0.5px;
-  margin-left: 0; 
-}
-
-/* --- Close Button --- */
-#previewCloseBtn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  border-radius: 12px;
-  background-color: #2c343b;
-  color: #e0f2e0;
-  border: 3px solid transparent;
-  transition: all 0.15s ease-out;
-  cursor: pointer;
-}
-
-#previewCloseBtn:hover {
-  filter: brightness(110%);
-}
-
-#previewCloseBtn:active {
-  background-color: #455256;
-  border-color: #e0f2e0;
-  box-shadow: inset 2px 2px 8px rgba(0, 0, 0, 0.5);
-}
-
-#previewCloseBtn svg {
-  fill: #e0f2e0;
-  stroke: #e0f2e0;
-  width: 22px;
-  height: 22px;
-  flex-shrink: 0;
-}
-
-/* --- Viewport Area --- */
-#previewVideo {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: fill;
-  z-index: 1;
-  pointer-events: none;
-}
-
-.preview-viewport {
-  position: relative;
-  flex-grow: 1;
-  width: 100%;
-  height: 100%;
-  background-color: #000;
-  overflow: hidden;
-}
-
-/* The Canvas layer for drawing the path lines */
-#previewCanvas {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 2;
-  pointer-events: none;
-}
-
-/* --- Simulation Marker (The moving dot) --- */
-#previewMarker {
-  position: absolute;
-  z-index: 10;
-  display: none;
-  pointer-events: none;
-  background-color: transparent;
-  border: 3px solid #70ff57;
-  border-radius: 50%;
-  box-sizing: border-box;
+.preview-toggle-container .segment-control {
+  background-color: #0f1419;
+  border: 1px solid #2c343b;
 }

--- a/frontend/src/styles/components/previewPage.css
+++ b/frontend/src/styles/components/previewPage.css
@@ -95,19 +95,26 @@
 }
 
 /* --- Viewport Area --- */
+#previewVideo {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: fill;   /* Crucial: matches main video distortion so paths align */
+  z-index: 1;         /* Sit behind the canvas (which is z-index: 2) */
+  pointer-events: none;
+}
+
+/* Update this existing class to remove the background image logic */
 .preview-viewport {
   position: relative;
   flex-grow: 1;
   width: 100%;
   height: 100%;
   background-color: #000;
-  /* Forces the snapshot to stretch exactly like the main video.
-     This ensures the aspect ratio distortion matches the calculated path. */
-  background-size: 100% 100%; 
-  background-repeat: no-repeat;
-  background-position: center;
-  
   overflow: hidden;
+  /* Remove background-size, background-repeat, etc. */
 }
 
 /* The Canvas layer for drawing the path lines */

--- a/frontend/src/styles/components/previewPage.css
+++ b/frontend/src/styles/components/previewPage.css
@@ -55,7 +55,7 @@
 #previewTimeDisplay {
   font-family: 'IBM Plex Sans', sans-serif;
   font-size: 14px;
-  color: #70ff57;
+  color: #e0f2e0b6;
   font-weight: 500;
   letter-spacing: 0.5px;
   margin-left: 0; 

--- a/frontend/src/styles/components/settingsPage.css
+++ b/frontend/src/styles/components/settingsPage.css
@@ -1,3 +1,5 @@
+/* frontend/src/styles/components/settingsPage.css */
+
 /* ============================================
    SETTINGS PAGE
    ============================================ */

--- a/frontend/src/styles/components/settingsPage.css
+++ b/frontend/src/styles/components/settingsPage.css
@@ -1,5 +1,3 @@
-/* frontend/src/styles/components/settingsPage.css */
-
 /* ============================================
    SETTINGS PAGE
    ============================================ */
@@ -15,6 +13,7 @@
   fill: #e0f2e0;
 }
 
+/* --- Modal Container --- */
 #overlay {
   position: fixed;
   top: 0;
@@ -22,13 +21,11 @@
   width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.6);
-  z-index: 100;
   display: none;
 }
 
 #settingsPopup {
   position: fixed;
-  z-index: 999;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
@@ -49,6 +46,7 @@
   display: flex;
 }
 
+/* --- Header --- */
 .settings-header {
   display: flex;
   justify-content: space-between;
@@ -78,6 +76,13 @@
   transition: all 0.15s ease-out;
 }
 
+#settingsCloseBtn svg {
+  fill: #e0f2e0;
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+}
+
 #settingsCloseBtn:hover {
   filter: brightness(110%);
 }
@@ -88,13 +93,7 @@
   box-shadow: inset 2px 2px 8px rgba(0, 0, 0, 0.5);
 }
 
-#settingsCloseBtn svg {
-  fill: #e0f2e0;
-  width: 22px;
-  height: 22px;
-  flex-shrink: 0;
-}
-
+/* --- Body Layout --- */
 .settings-body {
   display: flex;
   flex-grow: 1;
@@ -158,7 +157,7 @@
   margin-bottom: 1.5rem;
 }
 
-/* --- Setting Item & Toggle --- */
+/* --- Individual Setting Items --- */
 .setting-item {
   display: flex;
   align-items: center;
@@ -171,11 +170,7 @@
   font-weight: 400;
 }
 
-.setting-label-density {
-  font-size: 12px;
-  font-weight: 400;
-}
-
+/* --- Toggle Switches --- */
 .switch-container {
   display: flex;
   align-items: center;
@@ -235,10 +230,5 @@ input:checked+.slider:before {
   transform: translateX(26px);
 }
 
-.slider.round {
-  border-radius: 34px;
-}
-
-.slider.round:before {
-  border-radius: 50%;
-}
+.slider.round { border-radius: 34px; }
+.slider.round:before { border-radius: 50%; }

--- a/frontend/src/styles/style.css
+++ b/frontend/src/styles/style.css
@@ -10,22 +10,8 @@
 @import url('./components/previewPage.css');
 
 /* ============================================
-   GLOBAL STYLES & UTILITIES
+   GLOBAL STYLES & RESET
    ============================================ */
-
-#app-scaler {
-  transform-origin: top left;
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-
-* {
-  box-sizing: border-box;
-}
-
 html, body {
   margin: 0 !important;
   padding: 0 !important;
@@ -40,8 +26,17 @@ body {
   background-color: #000000;
 }
 
-#app {
-  max-width: 680px;
+* { box-sizing: border-box; }
+
+#app { max-width: 680px; }
+
+#app-scaler {
+  transform-origin: top left;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
 }
 
 button {
@@ -61,13 +56,10 @@ pre {
   white-space: pre-wrap;
 }
 
-.hidden,
-.hidden-mode {
-  display: none !important;
-}
+.hidden, .hidden-mode { display: none !important; }
 
 /* ============================================
-   TOP PANEL & STATUS
+   TOP PANEL (Header/Status)
    ============================================ */
 #top-panel {
   height: 60px;
@@ -80,6 +72,7 @@ pre {
   gap: 10px;
 }
 
+/* Status Panels */
 .status-message {
   display: flex;
   height: 100%;
@@ -112,6 +105,14 @@ pre {
   overflow: hidden;
 }
 
+#max-heat-container {
+  font-weight: bold;
+  color: #e0f2e0;
+  margin-left: auto;
+  padding-right: 10px;
+}
+
+/* Mode Switcher */
 .mode-label {
   display: flex;
   align-items: center;
@@ -149,7 +150,7 @@ pre {
 }
 
 /* ============================================
-   LEFT PANEL & CONTROLS
+   LEFT PANEL (Toolbar)
    ============================================ */
 #left-panel {
   height: calc(100% - 60px);
@@ -161,13 +162,16 @@ pre {
   background-color: #0f1419;
 }
 
-#top-icon-section {
+#top-icon-section,
+#settings-icon-section {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 10px;
   margin-top: 0.2vw;
 }
+
+#settings-icon-section { margin-bottom: 0.2vw; }
 
 #main-section-wrapper {
   flex-grow: 1;
@@ -184,13 +188,6 @@ pre {
   margin-bottom: auto;
 }
 
-#settings-icon-section {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin-bottom: 0.2vw;
-}
-
 .tool-group {
   display: flex;
   flex-direction: column;
@@ -200,52 +197,88 @@ pre {
 }
 
 /* ============================================
-   SLIDERS (VERTICAL & HORIZONTAL)
+   VIEWPORT AREA (Geometry Only)
    ============================================ */
-.brush-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 30px;
-  width: 100%;
+#viewport {
+  position: absolute;
+  top: 60px;
+  left: 65.5px;
+  width: calc(100% - 65.5px);
+  height: calc(100% - 60px);
+  overflow: hidden;
+  background-color: #000;
 }
 
-.brush-label {
-  color: #e0f2e0;
-  font-size: 0.8rem;
-  font-weight: bold;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  user-select: none;
+#video {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: fill;
   pointer-events: none;
 }
 
-.vertical-slider-container {
-  height: 170px;
+#canvas,
+.fabric-canvas-container,
+.fabric-canvas-container .lower-canvas, 
+.fabric-canvas-container .upper-canvas {
+  position: absolute !important;
+  top: 0 !important;
+  left: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+  touch-action: none;
+}
+
+.activeTool {
+  outline: 3px solid #6df06d;
+  border-radius: 6px;
+}
+
+#fixturesCanvas {
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  height: 100%;
+  pointer-events: none;
+  display: none;
+  opacity: 0.6;
 }
 
-.vertical-range {
-  width: 170px;
-  height: 6px;
-  transform: rotate(-90deg);
-  transform-origin: center;
-  margin: 0;
+#fixturesCanvas.active {
+  pointer-events: auto;
+  display: block;
 }
 
-.height-container {
+#robot-marker, #preview-marker {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: transparent;
+  pointer-events: none;
+  display: none;
+  transform: translate(-50%, -50%);
+}
+
+#robot-marker { border: 3px solid #70ff57; }
+
+/* ============================================
+   SLIDERS (Vertical & Horizontal)
+   ============================================ */
+.brush-container, .height-container {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
   margin-top: 30px;
   width: 100%;
 }
 
-.height-label {
+.height-container { gap: 4px; }
+
+.brush-label, .height-label {
   color: #e0f2e0;
   font-size: 0.8rem;
   font-weight: bold;
@@ -262,6 +295,14 @@ pre {
   pointer-events: none;
 }
 
+.vertical-slider-container {
+  height: 170px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .height-vertical-slider-container {
   height: 180px;
   width: 100%;
@@ -269,15 +310,6 @@ pre {
   justify-content: center;
   align-items: center;
   padding-top: 20px;
-}
-
-.height-vertical-range {
-  width: 210px;
-  min-width: 210px;
-  height: 6px;
-  transform: rotate(-90deg);
-  transform-origin: center;
-  margin: 0;
 }
 
 .styled-range {
@@ -301,111 +333,27 @@ pre {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
 }
 
-/* ============================================
-   CANVAS & VIDEO VIEWPORT
-   ============================================ */
-#viewport {
-  position: absolute;
-  top: 60px;
-  left: 65.5px;
-  width: calc(100% - 65.5px);
-  height: calc(100% - 60px);
-  overflow: hidden;
-  background-color: #000;
+.vertical-range {
+  width: 170px;
+  height: 6px;
+  transform: rotate(-90deg);
+  transform-origin: center;
+  margin: 0;
 }
 
-#video {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: fill;
-  z-index: 1;
-  pointer-events: none;
-}
-
-#canvas {
-  position: absolute !important;
-  top: 0 !important;
-  left: 0 !important;
-  width: 100% !important;
-  height: 100% !important;
-  touch-action: none;
-  /* This ensures canvas display size matches viewport */
-}
-
-#fixturesCanvas {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 10 !important;
-  pointer-events: none;
-  display: none;
-  opacity: 0.6;
-}
-
-#fixturesCanvas.active {
-  pointer-events: auto;
-  display: block;
-}
-
-/* Make sure both canvases are children of viewport */
-.fabric-canvas-container {
-  position: absolute !important;
-  top: 0 !important;
-  left: 0 !important;
-  width: 100% !important;
-  height: 100% !important;
-  z-index: 20;
-}
-
-.fabric-canvas-container .upper-canvas {
-  z-index: 20 !important;
-}
-
-
-.activeTool {
-  outline: 3px solid #6df06d;
-  border-radius: 6px;
-}
-
-#robot-marker {
-  position: absolute;
-  width: 24px;
-  height: 24px;
-  border: 3px solid #70ff57;
-  border-radius: 50%;
-  background-color: transparent;
-  pointer-events: none;
-  z-index: 50;
-  display: none;
-  transform: translate(-50%, -50%);
-}
-
-#max-heat-container {
-  font-weight: bold;
-  color: #e0f2e0;
-  margin-left: auto;
-  padding-right: 10px;
-}
-
-.fabric-canvas-container .lower-canvas, .fabric-canvas-container .upper-canvas {
-  z-index: 100 !important;
+.height-vertical-range {
+  width: 210px;
+  min-width: 210px;
+  height: 6px;
+  transform: rotate(-90deg);
+  transform-origin: center;
+  margin: 0;
 }
 
 /* ============================================
-   INDEPENDENT LAYOUT POSITIONING STYLES
+   LAYOUT MODIFIERS (Menu Position)
    ============================================ */
-#preparePopup {
-  --popup-edge-offset: 10px; /* ← must match the `right` value in preparePage.css */
-}
-
-/* ============================================
-   MENU AT BOTTOM
-   ============================================ */
+/* --- Menu Bottom --- */
 body.menu-bottom #top-panel {
   position: absolute;
   top: auto;
@@ -414,36 +362,27 @@ body.menu-bottom #top-panel {
   right: 0;
 }
 
-body.menu-bottom #viewport {
-  top: 0;
-  bottom: 60px;
-  height: calc(100% - 60px);
-}
-
+body.menu-bottom #viewport,
 body.menu-bottom #left-panel {
   top: 0;
   bottom: 60px;
   height: calc(100% - 60px);
 }
 
-/* --- Prepare popup: pin to top-left, top padding = normal right padding --- */
 body.menu-bottom #preparePopup {
-  top:    var(--popup-edge-offset);
-  left:   calc(var(--popup-edge-offset) + 65px);
-  right:  auto;
+  top: var(--popup-edge-offset);
+  left: calc(var(--popup-edge-offset) + 65px);
+  right: auto;
   bottom: auto;
 }
 
-/* --- Settings gear: move to top of the sidebar --- */
 body.menu-bottom #settings-icon-section {
-  order:         -1;
-  margin-top:    0.2vw;
+  order: -1;
+  margin-top: 0.2vw;
   margin-bottom: 0;
 }
 
-/* ============================================
-   SIDEBAR ON RIGHT
-   ============================================ */
+/* --- Sidebar Right --- */
 body.sidebar-right #left-panel {
   position: absolute;
   left: auto;
@@ -458,9 +397,7 @@ body.sidebar-right #viewport {
   width: calc(100% - 65.5px);
 }
 
-/* ============================================
-   COMBINED: MENU BOTTOM + SIDEBAR RIGHT
-   ============================================ */
+/* --- Combined: Menu Bottom + Sidebar Right --- */
 body.menu-bottom.sidebar-right #left-panel {
   top: 0;
   bottom: 60px;
@@ -473,4 +410,60 @@ body.menu-bottom.sidebar-right #viewport {
   bottom: 60px;
   width: calc(100% - 65.5px);
   height: calc(100% - 60px);
+}
+
+/* ============================================
+   Z-INDEX MANAGEMENT
+   ============================================ */
+/* Layer Order (Bottom to Top):
+   1. Video Stream (0)
+   2. Drawing / Fabric Canvas (10)
+   3. Preview Path Overlay (20)
+   4. Fixtures Canvas (30)
+   5. Heat Markers / Robot Markers (50)
+   6. UI Panels (Sidebars/Top) (60)
+   7. Overlay Dimmer (100)
+   8. Popups (Settings/Prepare) (101)
+*/
+
+/* Level 1 */
+#video {
+  z-index: 0;
+}
+
+/* Level 2 */
+.fabric-canvas-container,
+.fabric-canvas-container .lower-canvas, 
+.fabric-canvas-container .upper-canvas {
+  z-index: 10 !important; 
+}
+
+/* Level 3 */
+#previewOverlay {
+  z-index: 20 !important;
+}
+
+/* Level 4 */
+#fixturesCanvas {
+  z-index: 30 !important;
+}
+
+/* Level 5 */
+#robot-marker, #preview-marker {
+  z-index: 50 !important;
+}
+
+/* Level 6 */
+#left-panel, #top-panel {
+  z-index: 60;
+}
+
+/* Level 7 */
+#overlay {
+  z-index: 100;
+}
+
+/* Level 8 */
+#preparePopup, #settingsPopup {
+  z-index: 101;
 }

--- a/frontend/src/styles/style.css
+++ b/frontend/src/styles/style.css
@@ -1,3 +1,5 @@
+/* frontend/src/styles/style.css */
+
 /* ============================================
    FONTS & IMPORTS
    ============================================ */
@@ -5,6 +7,7 @@
 @import url('./components/buttons.css');
 @import url('./components/settingsPage.css');
 @import url('./components/preparePage.css');
+@import url('./components/previewPage.css');
 
 /* ============================================
    GLOBAL STYLES & UTILITIES

--- a/frontend/src/styles/style.css
+++ b/frontend/src/styles/style.css
@@ -69,7 +69,6 @@ pre {
   width: 100%;
   background-color: #0f1419;
   gap: 10px;
-  z-index: 1000;
 }
 
 /* Status Panels */
@@ -160,7 +159,6 @@ pre {
   width: 65.5px;
   flex-shrink: 0;
   background-color: #0f1419;
-  z-index: 1000;
 }
 
 #top-icon-section,

--- a/frontend/src/styles/style.css
+++ b/frontend/src/styles/style.css
@@ -18,6 +18,7 @@ body {
   padding: 0 !important;
   height: 100%;
   width: 100%;
+  user-select: none;
 }
 
 body {

--- a/frontend/src/styles/style.css
+++ b/frontend/src/styles/style.css
@@ -380,7 +380,7 @@ pre {
   border-radius: 50%;
   background-color: transparent;
   pointer-events: none;
-  z-index: 900;
+  z-index: 50;
   display: none;
   transform: translate(-50%, -50%);
 }

--- a/frontend/src/styles/style.css
+++ b/frontend/src/styles/style.css
@@ -324,9 +324,9 @@ pre {
 .styled-range::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
+  width: 20px;
+  height: 40px;
+  border-radius: 18px;
   background: #e0f2e0;
   cursor: pointer;
   border: 2px solid #2c343b;

--- a/frontend/src/styles/style.css
+++ b/frontend/src/styles/style.css
@@ -12,7 +12,8 @@
 /* ============================================
    GLOBAL STYLES & RESET
    ============================================ */
-html, body {
+html,
+body {
   margin: 0 !important;
   padding: 0 !important;
   height: 100%;
@@ -25,9 +26,13 @@ body {
   background-color: #000000;
 }
 
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+}
 
-#app { max-width: 680px; }
+#app {
+  max-width: 680px;
+}
 
 #app-scaler {
   transform-origin: top left;
@@ -55,7 +60,10 @@ pre {
   white-space: pre-wrap;
 }
 
-.hidden, .hidden-mode { display: none !important; }
+.hidden,
+.hidden-mode {
+  display: none !important;
+}
 
 /* ============================================
    TOP PANEL (Header/Status)
@@ -94,7 +102,7 @@ pre {
   display: flex;
   align-items: stretch;
   justify-content: flex-start;
-  background-color: #2c343b; 
+  background-color: #2c343b;
   border: 2px solid #2c343b;
   border-radius: 18px;
   padding: 0;
@@ -130,14 +138,14 @@ pre {
 .mode-btn-wrapper {
   display: flex;
   align-items: center;
-  background-color: #172027; 
+  background-color: #172027;
   padding: 4px;
   gap: 4px;
   height: 100%;
   flex-grow: 1;
   border-top-left-radius: 16px;
   border-bottom-left-radius: 16px;
-  border-top-right-radius: 0; 
+  border-top-right-radius: 0;
   border-bottom-right-radius: 0;
 }
 
@@ -170,7 +178,9 @@ pre {
   margin-top: 0.2vw;
 }
 
-#settings-icon-section { margin-bottom: 0.2vw; }
+#settings-icon-section {
+  margin-bottom: 0.2vw;
+}
 
 #main-section-wrapper {
   flex-grow: 1;
@@ -227,7 +237,7 @@ pre {
 
 #canvas,
 .fabric-canvas-container,
-.fabric-canvas-container .lower-canvas, 
+.fabric-canvas-container .lower-canvas,
 .fabric-canvas-container .upper-canvas {
   position: absolute !important;
   top: 0 !important;
@@ -258,7 +268,8 @@ pre {
   display: block;
 }
 
-#robot-marker, #preview-marker {
+#robot-marker,
+#preview-marker {
   position: absolute;
   width: 24px;
   height: 24px;
@@ -269,14 +280,19 @@ pre {
   transform: translate(-50%, -50%);
 }
 
-#preview-marker { border: 3px solid #FFA500}
+#preview-marker {
+  border: 3px solid #FFA500
+}
 
-#robot-marker { border: 3px solid #70ff57; }
+#robot-marker {
+  border: 3px solid #70ff57;
+}
 
 /* ============================================
    SLIDERS (Vertical & Horizontal)
    ============================================ */
-.brush-container, .height-container {
+.brush-container,
+.height-container {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -284,9 +300,12 @@ pre {
   width: 100%;
 }
 
-.height-container { gap: 4px; }
+.height-container {
+  gap: 4px;
+}
 
-.brush-label, .height-label {
+.brush-label,
+.height-label {
   color: #e0f2e0;
   font-size: 0.8rem;
   font-weight: bold;
@@ -424,65 +443,116 @@ body.menu-bottom.sidebar-right #viewport {
    THERMAL GRADIENT LEGEND (ULTRA-SLIM)
    ============================================ */
 #thermal-gradient-legend {
-    position: absolute;
-    left: 30px;
-    top: 50%;
-    transform: translateY(-50%);
-    z-index: 60;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 6px;
-    background-color: rgba(21, 27, 33, 0.85);
-    padding: 10px 8px;
-    border-radius: 8px;
-    border: 2px solid #2c343b;
-    pointer-events: none;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  position: absolute;
+  left: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  background-color: rgba(21, 27, 33, 0.85);
+  padding: 10px 8px;
+  border-radius: 8px;
+  border: 2px solid #2c343b;
+  pointer-events: none;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
 }
 
 .legend-core {
-    display: flex;
-    flex-direction: row;
-    align-items: stretch;
-    gap: 6px;
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 6px;
 }
 
 .gradient-bar {
-    width: 20px;
-    height: 200px;
-    background: linear-gradient(to top, 
-        #00007F 0%,    /* Dark Blue (20°C) */
-        #0000FF 12.5%, /* Blue */
-        #00FFFF 37.5%, /* Cyan */
-        #00FF00 50%,   /* Green (60°C) */
-        #FFFF00 62.5%, /* Yellow */
-        #FF0000 87.5%, /* Red */
-        #7F0000 100%   /* Dark Red (100°C) */
+  width: 20px;
+  height: 200px;
+  background: linear-gradient(to top,
+      #00007F 0%,
+      /* Dark Blue (20°C) */
+      #0000FF 12.5%,
+      /* Blue */
+      #00FFFF 37.5%,
+      /* Cyan */
+      #00FF00 50%,
+      /* Green (60°C) */
+      #FFFF00 62.5%,
+      /* Yellow */
+      #FF0000 87.5%,
+      /* Red */
+      #7F0000 100%
+      /* Dark Red (100°C) */
     );
-    border: 1px solid #e0f2e0;
-    border-radius: 4px;
+  border: 1px solid #e0f2e0;
+  border-radius: 4px;
 }
 
 .gradient-labels {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between; 
-    
-    color: #e0f2e0;
-    font-family: 'IBM Plex Sans', sans-serif;
-    font-size: 12px;
-    font-weight: 700;
-    padding: 1px 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  color: #e0f2e0;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 1px 0;
 }
 
 .legend-unit {
-    color: #a1b0a4;
-    font-family: 'IBM Plex Sans', sans-serif;
-    font-size: 12px;
-    font-weight: 700;
-    width: 100%;
-    text-align: left;
+  color: #a1b0a4;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  width: 100%;
+  text-align: left;
+}
+
+/* ============================================
+   INLINE ROBOT WARNING
+   ============================================ */
+#inline-robot-warning {
+  /* Width is intentionally omitted here; it is calculated dynamically in JS */
+  flex-shrink: 0;
+  flex-grow: 0;
+  box-sizing: border-box;
+  background-color: rgba(250, 133, 0, 0.1);
+  border: 1px solid #fa8500;
+  border-radius: 8px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+
+.inline-warning-text {
+  color: #fa8500;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 14px;
+  text-align: center;
+}
+
+.inline-warning-btn {
+  background-color: #fa8500;
+  color: #ffffff;
+  border: 1px solid transparent;
+  font-weight: 700;
+  font-size: 13px;
+  padding: 6px;
+  border-radius: 6px;
+  width: 100%;
+  cursor: pointer;
+  transition: filter 0.15s ease;
+}
+
+.inline-warning-btn:hover {
+  filter: brightness(115%);
 }
 
 /* ============================================
@@ -506,9 +576,9 @@ body.menu-bottom.sidebar-right #viewport {
 
 /* Level 2 */
 .fabric-canvas-container,
-.fabric-canvas-container .lower-canvas, 
+.fabric-canvas-container .lower-canvas,
 .fabric-canvas-container .upper-canvas {
-  z-index: 10 !important; 
+  z-index: 10 !important;
 }
 
 /* Level 3 */
@@ -522,12 +592,14 @@ body.menu-bottom.sidebar-right #viewport {
 }
 
 /* Level 5 */
-#robot-marker, #preview-marker {
+#robot-marker,
+#preview-marker {
   z-index: 50 !important;
 }
 
 /* Level 6 */
-#left-panel, #top-panel {
+#left-panel,
+#top-panel {
   z-index: 60;
 }
 
@@ -537,6 +609,7 @@ body.menu-bottom.sidebar-right #viewport {
 }
 
 /* Level 8 */
-#preparePopup, #settingsPopup {
+#preparePopup,
+#settingsPopup {
   z-index: 101;
 }

--- a/frontend/src/styles/style.css
+++ b/frontend/src/styles/style.css
@@ -421,6 +421,71 @@ body.menu-bottom.sidebar-right #viewport {
 }
 
 /* ============================================
+   THERMAL GRADIENT LEGEND (ULTRA-SLIM)
+   ============================================ */
+#thermal-gradient-legend {
+    position: absolute;
+    left: 30px;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 60;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    background-color: rgba(21, 27, 33, 0.85);
+    padding: 10px 8px;
+    border-radius: 8px;
+    border: 2px solid #2c343b;
+    pointer-events: none;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+.legend-core {
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    gap: 6px;
+}
+
+.gradient-bar {
+    width: 20px;
+    height: 200px;
+    background: linear-gradient(to top, 
+        #00007F 0%,    /* Dark Blue (20°C) */
+        #0000FF 12.5%, /* Blue */
+        #00FFFF 37.5%, /* Cyan */
+        #00FF00 50%,   /* Green (60°C) */
+        #FFFF00 62.5%, /* Yellow */
+        #FF0000 87.5%, /* Red */
+        #7F0000 100%   /* Dark Red (100°C) */
+    );
+    border: 1px solid #e0f2e0;
+    border-radius: 4px;
+}
+
+.gradient-labels {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between; 
+    
+    color: #e0f2e0;
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 12px;
+    font-weight: 700;
+    padding: 1px 0;
+}
+
+.legend-unit {
+    color: #a1b0a4;
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 12px;
+    font-weight: 700;
+    width: 100%;
+    text-align: left;
+}
+
+/* ============================================
    Z-INDEX MANAGEMENT
    ============================================ */
 /* Layer Order (Bottom to Top):

--- a/frontend/src/styles/style.css
+++ b/frontend/src/styles/style.css
@@ -263,6 +263,8 @@ pre {
   transform: translate(-50%, -50%);
 }
 
+#preview-marker { border: 3px solid #FFA500}
+
 #robot-marker { border: 3px solid #70ff57; }
 
 /* ============================================

--- a/frontend/src/ui/CanvasManager.ts
+++ b/frontend/src/ui/CanvasManager.ts
@@ -890,31 +890,35 @@ export class CanvasManager {
     }
 
     public updateCanvasSize(width: number, height: number): void {
-        // 1. Calculate the scaling factor based on the change
-        // Prevent division by zero if initialized incorrectly
         const scaleX = this.prevWidth ? width / this.prevWidth : 1;
         const scaleY = this.prevHeight ? height / this.prevHeight : 1;
 
-        // 2. Resize the actual fabric canvas container
         this.fCanvas.setDimensions({ width, height });
 
-        // 3. Iterate through all objects to reposition them relative to the new size
         this.fCanvas.getObjects().forEach(obj => {
-            // Scale the position
+            // 1. Scale Position
             const newLeft = obj.left * scaleX;
             const newTop = obj.top * scaleY;
 
+            // 2. Scale Dimensions (FIX)
+            // We multiply the existing scale factor by the new resize ratio
+            const newScaleX = obj.scaleX * scaleX;
+            const newScaleY = obj.scaleY * scaleY;
+
             obj.set({
                 left: newLeft,
-                top: newTop
+                top: newTop,
+                scaleX: newScaleX,
+                scaleY: newScaleY
             });
 
-            // Also scale specific custom properties for Markers
+            // Marker Handling (Keep existing custom logic)
             if ((obj as any)._isMarker) {
                 (obj as any)._tipX = (obj as any)._tipX * scaleX;
                 (obj as any)._tipY = (obj as any)._tipY * scaleY;
             }
-            obj.setCoords(); // Critical, recalculate hitboxes
+
+            obj.setCoords();
         });
 
         // 4. Handle Fixtures (Raster) Canvas Scaling

--- a/frontend/src/ui/CanvasManager.ts
+++ b/frontend/src/ui/CanvasManager.ts
@@ -681,7 +681,7 @@ export class CanvasManager {
 
         this.isDrawingHeatArea = false;
 
-        // Prevent tiny accidental clicks from registering as masks
+        //Prevent tiny accidental clicks from registering as masks
         if (this.activeHeatRect.width * this.activeHeatRect.scaleX < 5 ||
             this.activeHeatRect.height * this.activeHeatRect.scaleY < 5) {
             this.fCanvas.remove(this.activeHeatRect);
@@ -689,15 +689,15 @@ export class CanvasManager {
             return;
         }
 
-        // 1. Generate Mask and Send to Backend
+        //Generate Mask and Send to Backend
         await this.sendHeatMaskToServer(this.activeHeatRect);
 
-        // 2. Remove the visual rectangle (as requested: "finish drawing... it will disappear")
+        //Remove the visual rectangle (as requested: "finish drawing... it will disappear")
         this.fCanvas.remove(this.activeHeatRect);
         this.activeHeatRect = null;
         this.fCanvas.requestRenderAll();
 
-        // 3. Notify UI to enable the Reset Button
+        //Notify UI to enable the Reset Button
         this.onHeatAreaDefined();
     }
 

--- a/frontend/src/ui/CanvasManager.ts
+++ b/frontend/src/ui/CanvasManager.ts
@@ -169,6 +169,88 @@ export class CanvasManager {
     }
 
     // =========================================================================
+    // Preview Logic
+    // =========================================================================
+
+    // Return a snapshot of the current canvas state (markers/shapes)
+    public getCanvasDataURL(): string {
+        return this.fCanvas.toDataURL();
+    }
+
+    public async getPreviewPath(speed: number, raster_type: string, density: number, isFillEnabled: boolean): Promise<{ duration: number, path: Position[] }> {
+        // 1. Generate Pixel Path (Same as execute)
+        const pixels = this.generatePixelPath();
+
+        // 2. Normalize to Video Space
+        // We do this to ensure the preview matches what the robot "sees" relative to the camera frame
+        const videoPixels = pixels.map(p => ({
+            x: (p.x / this.fCanvas.getWidth()) * this.video.videoWidth,
+            y: (p.y / this.fCanvas.getHeight()) * this.video.videoHeight
+        }));
+
+        const formData = new FormData();
+        formData.append('speed', speed.toString());
+        formData.append('density', density.toString());
+        // JSON stringify the array for the backend
+        formData.append('pixels', JSON.stringify(videoPixels));
+        formData.append('is_fill', isFillEnabled.toString());
+
+        // Only append raster type if it exists
+        if (raster_type) {
+            formData.append('raster_type', raster_type);
+        }
+
+        // We don't strictly need the file for the dummy preview, 
+        // but if your backend validator requires it, we can send a dummy or the real blob.
+        // For the dummy endpoint in Python I marked 'file' as Optional, so we can skip it here.
+
+        const response = await this.postFormData('/api/preview', formData);
+
+        // Return exactly what the Python endpoint returns
+        return {
+            duration: response.duration,
+            path: response.path
+        };
+    }
+
+    //Helper for getPreviewPath and executePath
+    private async generateRasterBlob(): Promise<Blob> {
+        const width = this.fCanvas.getWidth();
+        const height = this.fCanvas.getHeight();
+        const tempCanvas = document.createElement('canvas');
+        tempCanvas.width = width;
+        tempCanvas.height = height;
+        const ctx = tempCanvas.getContext('2d', { willReadFrequently: true, alpha: false });
+        if (!ctx) throw new Error("Ctx error");
+
+        ctx.fillStyle = "#ffffff";
+        ctx.fillRect(0, 0, width, height);
+
+        this.fCanvas.getObjects().forEach(obj => {
+            if ((obj as any)._isMarker) return;
+            if (obj instanceof fabric.Line) return;
+
+            const originalFill = obj.fill;
+            const originalStroke = obj.stroke;
+
+            if (obj instanceof fabric.Line) {
+                obj.stroke = '#000000';
+                obj.fill = 'transparent';
+            } else {
+                obj.fill = '#000000';
+                obj.stroke = 'transparent';
+            }
+            obj.render(ctx);
+            obj.fill = originalFill;
+            obj.stroke = originalStroke;
+        });
+
+        const blob = await new Promise<Blob | null>(resolve => tempCanvas.toBlob(resolve, 'image/png'));
+        if (!blob) throw new Error("Blob error");
+        return blob;
+    }
+
+    // =========================================================================
     // Fixtures Mode Logic
     // =========================================================================
 
@@ -341,6 +423,12 @@ export class CanvasManager {
 
     public hasFixtures(): boolean {
         if (!this.fixturesCanvas || !this.fixturesCtx) return false;
+        
+        // --- GUARD CLAUSE: Prevent crash if canvas has 0 size ---
+        if (this.fixturesCanvas.width === 0 || this.fixturesCanvas.height === 0) {
+            return false;
+        }
+
         const imageData = this.fixturesCtx.getImageData(0, 0, this.fixturesCanvas.width, this.fixturesCanvas.height);
         const data = imageData.data;
         for (let i = 0; i < data.length; i += 4) {
@@ -1152,13 +1240,13 @@ export class CanvasManager {
         const jsonStr = JSON.stringify(data, null, 2);
         const blob = new Blob([jsonStr], { type: "application/json" });
         const url = URL.createObjectURL(blob);
-        
+
         const a = document.createElement('a');
         a.href = url;
         a.download = filename;
         document.body.appendChild(a);
         a.click();
-        
+
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
     }

--- a/frontend/src/ui/CanvasManager.ts
+++ b/frontend/src/ui/CanvasManager.ts
@@ -177,6 +177,25 @@ export class CanvasManager {
         return this.fCanvas.toDataURL();
     }
 
+    public getVideoSnapshotDataURL(): string {
+        //Create a temp canvas at the exact video resolution
+        const tempCanvas = document.createElement('canvas');
+        tempCanvas.width = this.video.videoWidth;
+        tempCanvas.height = this.video.videoHeight;
+        const ctx = tempCanvas.getContext('2d');
+
+        if (ctx) {
+            //Draw the video frame first (background)
+            ctx.drawImage(this.video, 0, 0, tempCanvas.width, tempCanvas.height);
+
+            //Draw the Fabric canvas on top (foreground)
+            //We use the raw canvas element from Fabric
+            ctx.drawImage(this.fCanvas.toCanvasElement(), 0, 0, tempCanvas.width, tempCanvas.height);
+        }
+
+        return tempCanvas.toDataURL('image/jpeg', 0.8); // JPEG is faster/smaller for video frames
+    }
+
     public async getPreviewPath(speed: number, raster_type: string, density: number, isFillEnabled: boolean): Promise<{ duration: number, path: Position[] }> {
         //Generate Pixel Path (Same as execute)
         const pixels = this.generatePixelPath();
@@ -421,7 +440,7 @@ export class CanvasManager {
 
     public hasFixtures(): boolean {
         if (!this.fixturesCanvas || !this.fixturesCtx) return false;
-        
+
         // --- GUARD CLAUSE: Prevent crash if canvas has 0 size ---
         if (this.fixturesCanvas.width === 0 || this.fixturesCanvas.height === 0) {
             return false;

--- a/frontend/src/ui/CanvasManager.ts
+++ b/frontend/src/ui/CanvasManager.ts
@@ -197,33 +197,30 @@ export class CanvasManager {
     }
 
     public async getPreviewPath(speed: number, raster_type: string, density: number, isFillEnabled: boolean): Promise<{ duration: number, path: Position[] }> {
-        //Generate Pixel Path (Same as execute)
-        const pixels = this.generatePixelPath();
+        // This method is now used only by PreviewManager for visualization
+        // It does not send data to backend, that's done by previewPath()
 
-        //Normalize to video space
-        //We do this to ensure the preview matches the camera frame
+        const pixels = this.generatePixelPath();
         const videoPixels = pixels.map(p => ({
             x: (p.x / this.fCanvas.getWidth()) * this.video.videoWidth,
             y: (p.y / this.fCanvas.getHeight()) * this.video.videoHeight
         }));
 
+        // For preview window visualization, we still need simulation data
+        // Real path computation happens in previewPath() -> backend
         const formData = new FormData();
         formData.append('speed', speed.toString());
         formData.append('density', density.toString());
-        // JSON stringify the array for the backend
         formData.append('pixels', JSON.stringify(videoPixels));
         formData.append('is_fill', isFillEnabled.toString());
 
-        // Only append raster type if it exists
         if (raster_type) {
             formData.append('raster_type', raster_type);
         }
 
-        //Probably want to send the file here as well, or whatever data we usually have for execute
-        //Right now it's just for the dummy path
+        // This still calls /api/preview but won't be confused with previewPath()
         const response = await this.postFormData('/api/preview', formData);
 
-        // Return exactly what the Python endpoint returns
         return {
             duration: response.duration,
             path: response.path
@@ -1175,97 +1172,61 @@ export class CanvasManager {
     }
 
     // =========================================================================
-    // Execution & Export Logic
+    // Preview/Execute Logic (NEW)
     // =========================================================================
 
-    public async executePath(speed: number, raster_type: string, density: number, isFillEnabled: boolean): Promise<any> {
-        // 1. Always generate the vector path (pixels)
+    /**
+     * Sends full path data to backend for preview/preparation
+     */
+    public async previewPath(speed: number, raster_type: string, density: number, isFillEnabled: boolean): Promise<{ duration: number, path: Position[] }> {
+        // Generate Pixel Path
         const pixels = this.generatePixelPath();
+
+        // Normalize to video space
         const videoPixels = pixels.map(p => ({
             x: (p.x / this.fCanvas.getWidth()) * this.video.videoWidth,
             y: (p.y / this.fCanvas.getHeight()) * this.video.videoHeight
         }));
 
-        //this.downloadJson(videoPixels, 'path-debug.json');
-
         const formData = new FormData();
-        formData.append('speed', (Number(speed) / 1000).toString());
-        if (isFillEnabled) {
-            formData.append('raster_type', raster_type);
-        }
+        formData.append('speed', speed.toString());
         formData.append('density', density.toString());
         formData.append('pixels', JSON.stringify(videoPixels));
         formData.append('is_fill', isFillEnabled.toString());
 
-        // 2. Generate raster image IF fill is enabled
+        if (raster_type) {
+            formData.append('raster_type', raster_type);
+        }
+
+        // Add raster mask if fill is enabled
         if (isFillEnabled) {
-            const width = this.fCanvas.getWidth();
-            const height = this.fCanvas.getHeight();
-            const tempCanvas = document.createElement('canvas');
-            tempCanvas.width = width;
-            tempCanvas.height = height;
-            const ctx = tempCanvas.getContext('2d', { willReadFrequently: true, alpha: false });
-            if (!ctx) throw new Error("Could not create temp context");
-
-            // No smoothing for sharp mask edges
-            ctx.imageSmoothingEnabled = false;
-            (ctx as any).mozImageSmoothingEnabled = false;
-            (ctx as any).webkitImageSmoothingEnabled = false;
-            (ctx as any).msImageSmoothingEnabled = false;
-
-            // White background
-            ctx.fillStyle = "#ffffff";
-            ctx.fillRect(0, 0, width, height);
-
-            // Render objects using Fabric's internal engine to handle rotation/scaling
-            this.fCanvas.getObjects().forEach(obj => {
-                if ((obj as any)._isMarker) return; // Skip markers
-                if (obj instanceof fabric.Line) return; // Skip Lines for Raster!
-
-                // Save original state
-                const originalFill = obj.fill;
-                const originalStroke = obj.stroke;
-
-                // Set mask style (Black = Raster Area)
-                if (obj instanceof fabric.Line) {
-                    // Lines have no fill, so we must draw the stroke in black
-                    obj.stroke = '#000000';
-                    obj.fill = 'transparent';
-                } else {
-                    obj.fill = '#000000';
-                    obj.stroke = 'transparent';
-                }
-
-                // Render with transforms applied automatically
-                obj.render(ctx);
-
-                // Restore state
-                obj.fill = originalFill;
-                obj.stroke = originalStroke;
-            });
-
-            const blob = await new Promise<Blob | null>(resolve => tempCanvas.toBlob(resolve, 'image/png'));
-            if (!blob) throw new Error("Failed to generate image blob");
+            const blob = await this.generateRasterBlob();
             formData.append('file', blob, 'path.png');
         }
 
-        return this.postFormData('/api/execute', formData);
+        const response = await this.postFormData('/api/preview', formData);
+
+        return {
+            duration: response.duration,
+            path: response.path
+        };
     }
 
-    //HELPER FOR IF YOU WANT TO DOWNLOAD THE GENERATED PATH FOR DEBUGGING
-    private downloadJson(data: any, filename: string): void {
-        const jsonStr = JSON.stringify(data, null, 2);
-        const blob = new Blob([jsonStr], { type: "application/json" });
-        const url = URL.createObjectURL(blob);
+    /**
+     * Sends execute command only (path should already be prepared)
+     */
+    public async executeCommand(): Promise<any> {
+        const response = await fetch(`${this.apiBaseUrl}/api/execute`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' }
+        });
 
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = filename;
-        document.body.appendChild(a);
-        a.click();
+        if (!response.ok) {
+            const errorData = await response.json().catch(() => ({ detail: response.statusText }));
+            throw new Error(errorData.detail || 'Execute command failed');
+        }
 
-        document.body.removeChild(a);
-        URL.revokeObjectURL(url);
+        return response.json();
     }
 
     public async updateViewSettings(isTransformedViewOn: boolean, isThermalViewOn: boolean = false): Promise<any> {
@@ -1354,20 +1315,19 @@ export class CanvasManager {
                     prevP = finalPt;
                 }
             } else if (obj instanceof fabric.Line) {
-                // 1. Get the line's start/end points relative to its center
+                //Proper coordinate transformation for lines
                 const line = obj as fabric.Line;
                 const points = line.calcLinePoints(); // {x1, y1, x2, y2}
 
-                // 2. Transform them to world coordinates using the matrix
+                //Transform start and end points using object's transform matrix
                 const start = new fabric.Point(points.x1, points.y1).transform(matrix);
                 const end = new fabric.Point(points.x2, points.y2).transform(matrix);
 
-                // 3. Generate pixels between the REAL start and end
+                //Generate pixels between the transformed points
                 const gen = Utils.generateLinePixels(start.x, start.y, end.x, end.y);
                 for (const p of gen) pixels.push(p);
-
             } else {
-                // Generic Fallback (Rects, Lines) -> Use getCoords() which returns the 4 corners (Transformed)
+                //Generic Fallback (Rects, Lines) -> Use getCoords() which returns the 4 corners (Transformed)
                 const coords = obj.getCoords(); // Returns [TL, TR, BR, BL] absolute coordinates
                 for (let i = 0; i < coords.length; i++) {
                     const start = coords[i];

--- a/frontend/src/ui/CanvasManager.ts
+++ b/frontend/src/ui/CanvasManager.ts
@@ -178,11 +178,11 @@ export class CanvasManager {
     }
 
     public async getPreviewPath(speed: number, raster_type: string, density: number, isFillEnabled: boolean): Promise<{ duration: number, path: Position[] }> {
-        // 1. Generate Pixel Path (Same as execute)
+        //Generate Pixel Path (Same as execute)
         const pixels = this.generatePixelPath();
 
-        // 2. Normalize to Video Space
-        // We do this to ensure the preview matches what the robot "sees" relative to the camera frame
+        //Normalize to video space
+        //We do this to ensure the preview matches the camera frame
         const videoPixels = pixels.map(p => ({
             x: (p.x / this.fCanvas.getWidth()) * this.video.videoWidth,
             y: (p.y / this.fCanvas.getHeight()) * this.video.videoHeight
@@ -200,10 +200,8 @@ export class CanvasManager {
             formData.append('raster_type', raster_type);
         }
 
-        // We don't strictly need the file for the dummy preview, 
-        // but if your backend validator requires it, we can send a dummy or the real blob.
-        // For the dummy endpoint in Python I marked 'file' as Optional, so we can skip it here.
-
+        //Probably want to send the file here as well, or whatever data we usually have for execute
+        //Right now it's just for the dummy path
         const response = await this.postFormData('/api/preview', formData);
 
         // Return exactly what the Python endpoint returns

--- a/frontend/src/ui/ToastManager.ts
+++ b/frontend/src/ui/ToastManager.ts
@@ -1,0 +1,94 @@
+export type ToastType = 'info' | 'warning' | 'error';
+
+export class ToastManager {
+    private static container: HTMLElement | null = null;
+
+    private static initContainer() {
+        if (this.container) return;
+
+        this.container = document.createElement('div');
+        this.container.id = 'toast-container';
+
+        // --- Position & Layout ---
+        this.container.style.position = 'absolute';
+        this.container.style.top = '70px'; // 60px header + 10px padding
+        this.container.style.left = '50%';
+        this.container.style.transform = 'translateX(-50%)';
+        this.container.style.zIndex = '9999';
+        
+        this.container.style.display = 'flex';
+        this.container.style.flexDirection = 'column';
+        this.container.style.gap = '10px';
+        this.container.style.pointerEvents = 'none'; // Clicks pass through the container gap
+        this.container.style.width = 'auto';
+        this.container.style.minWidth = '300px'; 
+        this.container.style.maxWidth = '90%';
+
+        // Attach to the scaler to match app zoom
+        const appScaler = document.getElementById('app-scaler');
+        if (appScaler) {
+            appScaler.appendChild(this.container);
+        } else {
+            document.body.appendChild(this.container);
+        }
+    }
+
+    public static show(message: string, type: ToastType = 'info', durationMs: number = 4000) {
+        this.initContainer();
+        if (!this.container) return;
+
+        const toast = document.createElement('div');
+        
+        // --- Content ---
+        // We can use a flex layout to allow for an icon in the future
+        toast.innerHTML = `<span style="flex-grow:1">${message}</span>`;
+
+        // --- Core Tech Styling ---
+        toast.style.fontFamily = "'IBM Plex Sans', sans-serif";
+        toast.style.fontSize = '14px';
+        toast.style.fontWeight = '500';
+        toast.style.letterSpacing = '0.5px';
+        toast.style.color = '#e0f2e0'; // Your app's off-white text color
+        
+        toast.style.background = '#151b21'; // Dark panel background
+        toast.style.border = '1px solid #2c343b'; // Thin tech border
+        toast.style.boxShadow = '0 6px 12px rgba(0,0,0,0.5)';
+        
+        toast.style.padding = '12px 16px';
+        toast.style.borderRadius = '4px'; // Sharper corners for industrial look
+        toast.style.pointerEvents = 'auto'; 
+        toast.style.display = 'flex';
+        toast.style.alignItems = 'center';
+        toast.style.justifyContent = 'space-between';
+        
+        // --- Status Strip (Left Border) ---
+        // Instead of a full colored background, we use a neon strip on the left
+        let accentColor = '#70ff57'; // Default Green
+        if (type === 'warning') accentColor = '#fa8500'; // Orange
+        if (type === 'error') accentColor = '#ef4444';   // Red
+
+        toast.style.borderLeft = `4px solid ${accentColor}`;
+
+        // --- Animation Start State ---
+        toast.style.opacity = '0';
+        toast.style.transform = 'translateY(-10px) scale(0.95)';
+        toast.style.transition = 'all 0.25s cubic-bezier(0.2, 0.8, 0.2, 1)';
+
+        this.container.appendChild(toast);
+
+        // Animate In
+        requestAnimationFrame(() => {
+            toast.style.opacity = '1';
+            toast.style.transform = 'translateY(0) scale(1)';
+        });
+
+        // Animate Out & Cleanup
+        setTimeout(() => {
+            toast.style.opacity = '0';
+            toast.style.transform = 'translateY(-10px) scale(0.95)';
+            toast.addEventListener('transitionend', () => {
+                toast.remove();
+            });
+        }, durationMs);
+    }
+}


### PR DESCRIPTION
Implemented path preview simulation logic
 - When you toggle the preview, it will show the path that the backend calculated based on the given drawing
 - Will indicate the length of time that it will take to complete the path
 - Marker will follow the path at the speed that it is estimated to run at

Misc Features
 - If the robot is off when you click execute, it will ask if you want to turn the robot on and then execute

UI Updates
 - Updated styling of previously existing buttons on the prepare menu
 - Added new preview path section, with another dropdown in the prepare menu
 - Updated the slider touch target to make it easier to press
 - Added a gradient to the heat page to show temperatures

Updated some safety features
 - If you try to draw outside of the camera window by moving/rotating a shape to go over the edge, it will not let you execute the path and will give a popup
 - If you draw outside of the fixtures you plan out, it will warn you, but allow you to continue

Minor fixes
 - You can now switch tabs and then move/rotate/resize the shape you drew again, instead of having to clear it
 - Theoretically keep track of last set robot height so as to not result in a position reset when you refresh the page

Probably some other stuff in here too but that's most of it